### PR TITLE
Using os.sep instead of "\\"

### DIFF
--- a/fitbenchmarking/example_runScripts.py
+++ b/fitbenchmarking/example_runScripts.py
@@ -1,4 +1,3 @@
-
 # script for running fit benchmarking and comparising the relative performance of local minimzers on
 # fit problems
 
@@ -7,25 +6,22 @@ import results_output as fitout
 
 import os
 
-#import mantid.simpleapi as msapi
+# Import mantid.simpleapi as msapi
 
 minimizers = ['BFGS', 'Conjugate gradient (Fletcher-Reeves imp.)',
-                                    'Conjugate gradient (Polak-Ribiere imp.)',
-                                   #'FABADA', # hide FABADA
+              'Conjugate gradient (Polak-Ribiere imp.)',
+              'Levenberg-Marquardt', 'Levenberg-MarquardtMD',
+              'Simplex', 'SteepestDescent',
+              'Trust Region', 'Damped GaussNewton']
 
-                                    'Levenberg-Marquardt', 'Levenberg-MarquardtMD',
-                                    'Simplex', 'SteepestDescent', 'Trust Region']
-
-minimizers = ['BFGS', 'Damped GaussNewton']                                    
-
-group_names = ['NIST, "lower" difficulty', 'NIST, "average" difficulty', 'NIST, "higher" difficulty', "CUTEst", "Neutron data"]
+group_names = ['NIST, "lower" difficulty', 'NIST, "average" difficulty',
+               'NIST, "higher" difficulty', "CUTEst", "Neutron data"]
 group_suffix_names = ['nist_lower', 'nist_average', 'nist_higher', 'cutest', 'neutron_data']
 color_scale = [(1.1, 'ranking-top-1'),
-                            (1.33, 'ranking-top-2'),
-                            (1.75, 'ranking-med-3'),
-                            (3, 'ranking-low-4'),
-                            (float('nan'), 'ranking-low-5')
-                           ]
+               (1.33, 'ranking-top-2'),
+               (1.75, 'ranking-med-3'),
+               (3, 'ranking-low-4'),
+               (float('nan'), 'ranking-low-5')]
 
 
 input_data_dir = os.path.dirname(os.path.realpath(__file__))
@@ -45,20 +41,17 @@ run_data = "neutron"
 
 if run_data == "neutron":
     problems, results_per_group = fitbk.do_fitting_benchmark(neutron_data_group_dirs=neutron_data_group_dirs,
-                                                     minimizers=minimizers, use_errors=use_errors)
+                                                             minimizers=minimizers, use_errors=use_errors)
 elif run_data == "muon":
     group_names = ['MUON']
     group_suffix_names = ['MUON']
     problems, results_per_group = fitbk.do_fitting_benchmark(muon_data_group_dir=muon_data_group_dir,
-                                                     minimizers=minimizers, use_errors=use_errors)  
-elif run_data=="nist":
-    #nist data
-     problems, results_per_group = fitbk.do_fitting_benchmark(nist_group_dir=nist_group_dir,
-                                                      minimizers=minimizers, use_errors=use_errors)            
-                                                      
-group_names = ['NIST, "lower" difficulty']
-group_suffix_names = ['nist_lower']
-    
+                                                             minimizers=minimizers, use_errors=use_errors)
+elif run_data == "nist":
+    # NIST data
+    problems, results_per_group = fitbk.do_fitting_benchmark(nist_group_dir=nist_group_dir,
+                                                             minimizers=minimizers, use_errors=use_errors)
+
 for idx, group_results in enumerate(results_per_group):
         print("\n\n")
         print("********************************************************")
@@ -74,5 +67,4 @@ for idx, group_results in enumerate(results_per_group):
 header = '\n\n**************** OVERALL SUMMARY - ALL GROUPS ******** \n\n'
 print(header)
 fitout.print_overall_results_table(minimizers, results_per_group, problems, group_names,
-                                       use_errors=use_errors, save_to_file=True)
-
+                                   use_errors=use_errors, save_to_file=True)

--- a/fitbenchmarking/example_runScripts.py
+++ b/fitbenchmarking/example_runScripts.py
@@ -6,8 +6,6 @@ import results_output as fitout
 
 import os
 
-# Import mantid.simpleapi as msapi
-
 minimizers = ['BFGS', 'Conjugate gradient (Fletcher-Reeves imp.)',
               'Conjugate gradient (Polak-Ribiere imp.)',
               'Levenberg-Marquardt', 'Levenberg-MarquardtMD',

--- a/fitbenchmarking/fitting_benchmarking.py
+++ b/fitbenchmarking/fitting_benchmarking.py
@@ -126,17 +126,17 @@ def do_fitting_benchmark(nist_group_dir=None, cutest_group_dir=None, neutron_dat
     problem_blocks = []
 
     if nist_group_dir:
-        # get NIST problems grouped into blocks of problems, in blocks of increasing difficulty
         problem_blocks.extend(get_nist_problem_files(nist_group_dir))
 
     if cutest_group_dir:
-        # get CUTEet problems - just treated as one block of problems
         problem_blocks.extend([get_cutest_problem_files(cutest_group_dir)])
 
     if neutron_data_group_dirs:
         problem_blocks.extend(get_data_groups(neutron_data_group_dirs))
+
     if muon_data_group_dir:
         problem_blocks.extend(get_data_groups(muon_data_group_dir))
+
 
     prob_results = [do_fitting_benchmark_group(block, minimizers, use_errors=use_errors) for
                     block in problem_blocks]
@@ -169,9 +169,10 @@ def do_fitting_benchmark_group(problem_files, minimizers, use_errors=True):
     results_per_problem = []
     count =0
     previous_name="none"
+
+    # Note the CUTEst problem are assumed to be expressed in NIST format
     for prob_file in problem_files:
         try:
-            # Note the CUTEst problem are assumed to be expressed in NIST format
             prob = iparsing.load_nist_fitting_problem_file(prob_file)
         except (AttributeError, RuntimeError):
             prob = iparsing.load_neutron_data_fitting_problem_file(prob_file)
@@ -179,7 +180,7 @@ def do_fitting_benchmark_group(problem_files, minimizers, use_errors=True):
         print("* Testing fitting for problem definition file {0}".format(prob_file))
         print("* Testing fitting of problem {0}".format(prob.name))
 
-        results_prob = do_fitting_benchmark_one_problem(prob, minimizers, use_errors,count,previous_name)
+        results_prob = do_fitting_benchmark_one_problem(prob, minimizers, use_errors, count, previous_name)
         results_per_problem.extend(results_prob)
 
     return problems, results_per_problem
@@ -473,7 +474,6 @@ def get_cutest_problem_files(search_dir):
 
 
 def get_data_groups(data_groups_dirs):
-
     problem_groups = []
     for grp_dir in data_groups_dirs:
         problem_groups.append(get_data_group_problem_files(grp_dir))
@@ -488,5 +488,9 @@ def get_data_group_problem_files(grp_dir):
     probs = glob.glob(search_str)
 
     probs.sort()
-    print ("Found test problem files: ", probs)
+
+    print ("Found test problem files:")
+    for problem in probs:
+        print(problem)
+    print("\n")
     return probs

--- a/fitbenchmarking/input_parsing.py
+++ b/fitbenchmarking/input_parsing.py
@@ -223,11 +223,17 @@ def load_neutron_data_fitting_problem_file(fname):
 
         entries = get_neutron_data_problem_entries(probf)
 
-        k = -1
+        # switch is used to find the last separator in the problem file path
+        # and set up the path for the data_files folder
+        # i.e truncates the path to ../Neutron_data
+        # and adds ../Neutron_data/data_files
+        # THE WAY THE DATA FILES PATH IS OBTAINED SHOULD CHANGE IN THE NEAR FUTURE
+
+        sep_idx = -1
         prefix = ""
 
-        k = fname.rfind(os.sep)
-        if k != -1:
+        sep_idx = fname.rfind(os.sep)
+        if sep_idx != -1:
             prefix = os.path.join(fname[:k],"data_files")
 
         prob = test_problem.FittingTestProblem()

--- a/fitbenchmarking/input_parsing.py
+++ b/fitbenchmarking/input_parsing.py
@@ -218,16 +218,20 @@ def load_neutron_data_fitting_problem_file(fname):
 
     @param fname :: name of the file to load
     """
+
     with open(fname) as probf:
+
         entries = get_neutron_data_problem_entries(probf)
-        # get the path to the data
-        k=-1
-        prefix =""
-        k = fname.rfind("\\")
+
+        k = -1
+        prefix = ""
+
+        k = fname.rfind(os.sep)
         if k != -1:
-            prefix = fname[:k]+"\\data_files\\"
+            prefix = os.path.join(fname[:k],"data_files")
+
         prob = test_problem.FittingTestProblem()
-        get_fitting_neutron_data(prefix+entries['input_file'], prob)
+        get_fitting_neutron_data(os.path.join(prefix,entries['input_file']), prob)
         prob.name = entries['name']
         prob.equation = entries['function']
         prob.starting_values = None
@@ -243,6 +247,7 @@ def get_neutron_data_problem_entries(problem_file):
     Get values from the lines of a "neutron fitting problem definition file",
     They are returned as a dictionary of key (lhs) - value (rhs).
     """
+
     entries = {}
     for line in problem_file:
         # discard comments
@@ -267,8 +272,10 @@ def get_fitting_neutron_data(fname, prob):
     @param fname :: file name to load (using mantid loaders)
     @param prob :: problem definition to populate with X-Y-E data.
     """
+
     import mantid.simpleapi as msapi
-    wks = msapi.Load(fname)
+
+    wks = msapi.Load(Filename=fname)
     prob.data_pattern_in = wks.readX(0)
     prob.data_pattern_out = wks.readY(0)
     prob.data_pattern_obs_errors = wks.readE(0)

--- a/fitbenchmarking/input_parsing.py
+++ b/fitbenchmarking/input_parsing.py
@@ -227,7 +227,6 @@ def load_neutron_data_fitting_problem_file(fname):
         # and set up the path for the data_files folder
         # i.e truncates the path to ../Neutron_data
         # and adds ../Neutron_data/data_files
-        # THE WAY THE DATA FILES PATH IS OBTAINED SHOULD CHANGE IN THE NEAR FUTURE
 
         sep_idx = -1
         prefix = ""


### PR DESCRIPTION
This is the first PR

Problem with importing the file is fixed if os.sep is used instead of "\\" at https://github.com/mantidproject/fitbenchmarking/blob/29eaecbf601dd392dc82d2d8844f871ebb5ba78e/fitbenchmarking/input_parsing.py#L226

To test:
1. Make sure that run_data = "neutron" in example_runScript.py
2. Run example_runScript in the mantidpython console
3. Check if the right neutron files are imported (i.e. compare console output with the files in the fitbenchmarking/benchmark_problems/Neutron_data)