### PR TITLE
Docutils dependency now included in setup.py

### DIFF
--- a/fitbenchmarking/example_runScripts.py
+++ b/fitbenchmarking/example_runScripts.py
@@ -1,12 +1,20 @@
 # script for running fit benchmarking and comparising the relative performance of local minimzers on
 # fit problems
 
+import os
+
+# If OS is Ubuntu
+if os.name == 'posix':
+	try:
+		import docutils
+	except:
+		raise ImportError("Please run 'sudo apt-get install python-docutils' in the terminal")
+
 import fitting_benchmarking as fitbk
 import results_output as fitout
 
-import os
 
-# Import mantid.simpleapi as msapi
+
 
 minimizers = ['BFGS', 'Conjugate gradient (Fletcher-Reeves imp.)',
               'Conjugate gradient (Polak-Ribiere imp.)',

--- a/fitbenchmarking/example_runScripts.py
+++ b/fitbenchmarking/example_runScripts.py
@@ -1,15 +1,6 @@
 # script for running fit benchmarking and comparising the relative performance of local minimzers on
 # fit problems
 
-import os
-
-# If OS is Ubuntu
-if os.name == 'posix':
-	try:
-		import docutils
-	except:
-		raise ImportError("Please run 'sudo apt-get install python-docutils' in the terminal")
-
 import fitting_benchmarking as fitbk
 import results_output as fitout
 

--- a/fitbenchmarking/example_runScripts.py
+++ b/fitbenchmarking/example_runScripts.py
@@ -1,6 +1,7 @@
 # script for running fit benchmarking and comparising the relative performance of local minimzers on
 # fit problems
 
+import os
 import fitting_benchmarking as fitbk
 import results_output as fitout
 

--- a/fitbenchmarking/post_processing.py
+++ b/fitbenchmarking/post_processing.py
@@ -30,49 +30,6 @@ except ImportError:
     from scipy.stats import nanmean, nanmedian
 
 
-def calc_summary_table(minimizers, group_results):
-    """
-    Calculates a summary from problem-individual results. At the moment the only summary
-    statistic calculated is the median. The output is produced as numpy matrices.
-
-    @param minimizers :: list of minimizers used (their names)
-
-    @param group_results :: results from running fitting tests on different problems (list
-    of lists, where the first level is the group, and the second level is the individual test).
-
-
-    @returns two numpy matrices (where columns are the groups, and rows are the minimizers)
-    with summary statistic (median) from the problem-individual results.
-    """
-
-    num_groups = len(group_results)
-    num_minimizers = len(minimizers)
-
-    groups_norm_acc = np.zeros((num_groups, num_minimizers))
-    groups_norm_runtime = np.zeros((num_groups, num_minimizers))
-    for group_idx, results_per_test in enumerate(group_results):
-        num_tests = len(results_per_test)
-        accuracy_tbl = np.zeros((num_tests, num_minimizers))
-        time_tbl = np.zeros((num_tests, num_minimizers))
-
-        for test_idx in range(0, num_tests):
-            for minimiz_idx in range(0, num_minimizers):
-                accuracy_tbl[test_idx, minimiz_idx] = results_per_test[test_idx][minimiz_idx].sum_err_sq
-                time_tbl[test_idx, minimiz_idx] = results_per_test[test_idx][minimiz_idx].runtime
-
-        # Min across all alternative runs/minimizers
-        min_sum_err_sq = np.nanmin(accuracy_tbl, 1)
-        min_runtime = np.nanmin(time_tbl, 1)
-
-        norm_acc_rankings = accuracy_tbl / min_sum_err_sq[:, None]
-        norm_runtime_rankings = time_tbl / min_runtime[:, None]
-
-        groups_norm_acc[group_idx, :] = nanmedian(norm_acc_rankings, 0)
-        groups_norm_runtime[group_idx, :] = nanmedian(norm_runtime_rankings, 0)
-
-    return groups_norm_acc, groups_norm_runtime
-
-
 def calc_accuracy_runtime_tbls(results_per_test, minimizers):
     """
     This produces a numpy matrix for convenience, with
@@ -121,3 +78,46 @@ def calc_norm_summary_tables(accuracy_tbl, time_tbl):
                                       ])
 
     return norm_acc_rankings, norm_runtimes, summary_cells_acc, summary_cells_runtime
+
+
+def calc_summary_table(minimizers, group_results):
+    """
+    Calculates a summary from problem-individual results. At the moment the only summary
+    statistic calculated is the median. The output is produced as numpy matrices.
+
+    @param minimizers :: list of minimizers used (their names)
+
+    @param group_results :: results from running fitting tests on different problems (list
+    of lists, where the first level is the group, and the second level is the individual test).
+
+
+    @returns two numpy matrices (where columns are the groups, and rows are the minimizers)
+    with summary statistic (median) from the problem-individual results.
+    """
+
+    num_groups = len(group_results)
+    num_minimizers = len(minimizers)
+
+    groups_norm_acc = np.zeros((num_groups, num_minimizers))
+    groups_norm_runtime = np.zeros((num_groups, num_minimizers))
+    for group_idx, results_per_test in enumerate(group_results):
+        num_tests = len(results_per_test)
+        accuracy_tbl = np.zeros((num_tests, num_minimizers))
+        time_tbl = np.zeros((num_tests, num_minimizers))
+
+        for test_idx in range(0, num_tests):
+            for minimiz_idx in range(0, num_minimizers):
+                accuracy_tbl[test_idx, minimiz_idx] = results_per_test[test_idx][minimiz_idx].sum_err_sq
+                time_tbl[test_idx, minimiz_idx] = results_per_test[test_idx][minimiz_idx].runtime
+
+        # Min across all alternative runs/minimizers
+        min_sum_err_sq = np.nanmin(accuracy_tbl, 1)
+        min_runtime = np.nanmin(time_tbl, 1)
+
+        norm_acc_rankings = accuracy_tbl / min_sum_err_sq[:, None]
+        norm_runtime_rankings = time_tbl / min_runtime[:, None]
+
+        groups_norm_acc[group_idx, :] = nanmedian(norm_acc_rankings, 0)
+        groups_norm_runtime[group_idx, :] = nanmedian(norm_runtime_rankings, 0)
+
+    return groups_norm_acc, groups_norm_runtime

--- a/fitbenchmarking/results_output.py
+++ b/fitbenchmarking/results_output.py
@@ -23,6 +23,7 @@ formats such as RST and plain text.
 # Code Documentation is available at: <http://doxygen.mantidproject.org>
 
 from __future__ import (absolute_import, division, print_function)
+
 import numpy as np
 from docutils.core import publish_string
 import post_processing as postproc

--- a/fitbenchmarking/results_output.py
+++ b/fitbenchmarking/results_output.py
@@ -71,7 +71,6 @@ def print_group_results_tables(minimizers, results_per_test, problems_obj, group
                           at the moment).
     """
     linked_problems = build_indiv_linked_problems(results_per_test, group_name)
-
     # Calculate summary tables
     accuracy_tbl, runtime_tbl = postproc.calc_accuracy_runtime_tbls(results_per_test, minimizers)
     norm_acc_rankings, norm_runtimes, summary_cells_acc, summary_cells_runtime = \
@@ -134,32 +133,6 @@ def print_group_results_tables(minimizers, results_per_test, problems_obj, group
         print(tbl_runtime_summary)
 
 
-def save_table_to_file(table_data, errors, group_name, metric_type, file_extension):
-    """
-    Saves a group results table or overall results table to a given file type.
-
-    @param table_data :: the results table
-    @param errors :: whether to use observational errors
-    @param group_name :: name of this group of problems (example 'NIST "lower difficulty"', or
-                         'Neutron data')
-    @param metric_type :: the test type of the table data (e.g. runtime, accuracy)
-    @param file_extension :: the file type extension (e.g. html)
-    """
-    file_name = ('comparison_{weighted}_{version}_{metric_type}_{group_name}.'
-                 .format(weighted=weighted_suffix_string(errors),
-                         version=BENCHMARK_VERSION_STR, metric_type=metric_type, group_name=group_name))
-
-    if file_extension == 'html':
-        rst_content = '.. include:: ' + str(os.path.join(SCRIPT_DIR, 'color_definitions.txt'))
-        rst_content += '\n' + table_data
-        table_data = publish_string(rst_content, writer_name='html')
-
-    with open(file_name + file_extension, 'w') as tbl_file:
-        print(table_data, file=tbl_file)
-    print('Saved {file_name}{extension} to {working_directory}'.
-          format(file_name=file_name, extension=file_extension, working_directory=WORKING_DIR))
-
-
 def build_indiv_linked_problems(results_per_test, group_name):
     """
     Makes a list of linked problem names which would be used for the
@@ -173,9 +146,11 @@ def build_indiv_linked_problems(results_per_test, group_name):
     prev_name = ''
     prob_count = 1
     linked_problems = []
+
     for test_idx, prob_results in enumerate(results_per_test):
         raw_name = results_per_test[test_idx][0].problem.name
         name = raw_name.split('.')[0]
+
         if name == prev_name:
             prob_count += 1
         else:
@@ -194,304 +169,6 @@ def build_indiv_linked_problems(results_per_test, group_name):
             linked_problems.append(name)
 
     return linked_problems
-
-
-def build_group_linked_names(group_names):
-    """
-    Add a link for RST tables if there is a website or similar describing the group.
-
-    @param group_names :: names as plain text
-
-    @returns :: names with RST links if available
-    """
-    linked_names = []
-    for name in group_names:
-        # This should be tidied up. We currently don't have links for groups other than NIST
-        if 'NIST' in name:
-            linked = "`{0} <http://www.itl.nist.gov/div898/strd/nls/nls_main.shtml>`__".format(name)
-        else:
-            linked = name
-
-        linked_names.append(linked)
-
-    return linked_names
-
-
-def build_visual_display_page(prob_results, group_name):
-    """
-    Builds a page containing details of the best fit for a problem.
-    @param prob_results:: the list of results for a problem
-    @param group_name :: the name of the group, e.g. "nist_lower"
-    """
-    # Get the best result for a group
-    gb = min((result for result in prob_results), key=lambda result: result.fit_chi2)
-    file_name = (group_name + '_' + gb.problem.name).lower()
-    wks = msapi.CreateWorkspace(OutputWorkspace=gb.problem.name, DataX=gb.problem.data_pattern_in, DataY=gb.problem.data_pattern_out)
-    # Create various page headings, ensuring the adornment is (at least) the length of the title
-    title = '=' * len(gb.problem.name) + '\n'
-    title += gb.problem.name + '\n'
-    title += '=' * len(gb.problem.name) + '\n\n'
-    data_plot = 'Plot of the data' + '\n'
-    data_plot += ('-' * len(data_plot)) + '\n\n'
-    data_plot += '.. image:: ' + file_name + '.png' + '\n\n'
-    starting_plot = 'Plot of the initial starting guess' + '\n'
-    starting_plot += ('-' * len(starting_plot)) + '\n\n'
-    starting_plot += '.. figure:: ' + '\n\n'
-    solution_plot = 'Plot of the solution found' + '\n'
-    solution_plot += ('-' * len(solution_plot)) + '\n\n'
-    solution_plot += '.. figure:: ' + '\n\n'
-    problem = 'Fit problem' + '\n'
-    problem += ('-' * len(problem)) + '\n'
-    rst_text = title + data_plot + starting_plot + solution_plot + problem
-
-    html = publish_string(rst_text, writer_name='html')
-    with open(file_name + '.' + FILENAME_EXT_TXT, 'w') as visual_rst:
-        print(html, file=visual_rst)
-        print('Saved {file_name}.{extension} to {working_directory}'.
-              format(file_name=file_name, extension=FILENAME_EXT_TXT, working_directory=WORKING_DIR))
-    with open(file_name + '.' + FILENAME_EXT_HTML, 'w') as visual_html:
-        print(html, file=visual_html)
-        print('Saved {file_name}.{extension} to {working_directory}'.
-              format(file_name=file_name, extension=FILENAME_EXT_HTML, working_directory=WORKING_DIR))
-
-    rst_link = '`<' + file_name + '.' + FILENAME_EXT_HTML + '>`_'  # `<cutest_palmer6c.dat.html>`_
-    return rst_link
-
-
-def print_overall_results_table(minimizers, group_results, problems, group_names, use_errors,
-                                simple_text=True, save_to_file=False):
-
-    groups_norm_acc, groups_norm_runtime = postproc.calc_summary_table(minimizers, group_results)
-
-    grp_linked_names = build_group_linked_names(group_names)
-
-    header = '**************** Accuracy ******** \n\n'
-    print(header)
-    tbl_all_summary_acc = build_rst_table(minimizers, grp_linked_names, groups_norm_acc,
-                                          comparison_type='summary', comparison_dim='accuracy',
-                                          using_errors=use_errors)
-    print(tbl_all_summary_acc)
-
-    if save_to_file:
-        save_table_to_file(tbl_all_summary_acc, use_errors, 'summary', FILENAME_SUFFIX_ACCURACY, FILENAME_EXT_TXT)
-        save_table_to_file(tbl_all_summary_acc, use_errors, 'summary', FILENAME_SUFFIX_ACCURACY, FILENAME_EXT_HTML)
-    header = '**************** Runtime ******** \n\n'
-    print (header)
-    tbl_all_summary_runtime = build_rst_table(minimizers, grp_linked_names, groups_norm_runtime,
-                                              comparison_type='summary', comparison_dim='runtime',
-                                              using_errors=use_errors)
-    if save_to_file:
-        save_table_to_file(tbl_all_summary_runtime, use_errors, 'summary', FILENAME_SUFFIX_RUNTIME, FILENAME_EXT_TXT)
-        save_table_to_file(tbl_all_summary_runtime, use_errors, 'summary', FILENAME_SUFFIX_RUNTIME, FILENAME_EXT_HTML)
-
-
-def weighted_suffix_string(use_errors):
-    """
-    Produces a suffix weighted/unweighted. Used to generate names of
-    output files.
-    """
-    values = {True: 'weighted', False: 'unweighted'}
-    return values[use_errors]
-
-
-def display_name_for_minimizers(names):
-    """
-    Converts minimizer names into their "display names". For example
-    to rename DTRS to "Trust region" or similar
-
-    """
-    display_names = names
-    # Quick fix for DTRS name in version 3.8 - REMOVE
-    for idx, minimizer in enumerate(names):
-        if 'DTRS' == minimizer:
-            display_names[idx] = 'Trust Region'
-
-    return display_names
-
-
-def calc_cell_len_rst_table(columns_txt, items_link, cells, color_scale=None):
-    """
-    Calculate ascii character width needed for an RST table, using the length of the longest table cell.
-
-    @param columns_txt :: list of the contents of the column headers
-    @param items_link :: the links from rst table cells to other pages/sections of pages
-    @param cells :: the values of the results
-    @param color_scale :: whether a color_scale is used or not
-    @returns :: the length of the longest cell in a table
-    """
-
-    # The length of the longest header (minimizer name)
-    max_header = len(max((col for col in columns_txt), key=len))
-    # The value of the longest (once formatted) value in the table
-    max_value = max(("%.4g" % cell for cell in np.nditer(cells)), key=len)
-    # The length of the longest link reference (angular bracket content present in summary tables)
-    max_item = max(items_link, key=len) if isinstance(items_link, list) else items_link
-    # One space on each end of a cell
-    padding = 2
-    # Set cell length equal to the length of: the longest combination of value, test name, and colour (plus padding)
-    cell_len = len(format_cell_value_rst(value=float(max_value),
-                                         color_scale=color_scale,
-                                         items_link=max_item).strip()) + padding
-    # If the header is longer than any cell's contents, i.e. is a group results table, use that length instead
-    if cell_len < max_header:
-        cell_len = max_header
-
-    return cell_len
-
-
-def build_rst_table(columns_txt, rows_txt, cells, comparison_type, comparison_dim,
-                    using_errors, color_scale=None):
-    """"
-    Builds an RST table as a string, given the list of column and row headers,
-    and a 2D numpy array with values for the cells.
-    This can be tricky/counterintuitive, see:
-    http://docutils.sourceforge.net/docs/dev/rst/problems.html
-
-    @param columns_txt :: the text for the columns, one item per column
-    @param rows_txt :: the text for the rows (will go in the leftmost column)
-    @param cells :: a 2D numpy array with as many rows as items have been given
-    in rows_txt, and as many columns as items have been given in columns_txt
-
-    @param comparison_type :: whether this is a 'summary', or a full 'accuracy', or 'runtime'
-                              table.
-    @param comparison_dim :: dimension (accuracy / runtime)
-    @param using_errors :: whether this comparison uses errors in the cost function
-    (weighted or unweighted), required to link the table properly
-
-    @param color_scale :: list with pairs of threshold value - color, to produce color
-    tags for the cells
-    """
-    columns_txt = display_name_for_minimizers(columns_txt)
-
-    items_link = build_items_links(comparison_type, comparison_dim, using_errors)
-
-    cell_len = calc_cell_len_rst_table(columns_txt, items_link, cells, color_scale)
-
-    # The first column tends to be disproportionately long if it has a link
-    first_col_len = calc_first_col_len(cell_len, rows_txt)
-
-    tbl_header_top, tbl_header_text, tbl_header_bottom = build_rst_table_header_chunks(first_col_len, cell_len,
-                                                                                       columns_txt)
-
-    tbl_header = tbl_header_top + '\n' + tbl_header_text + '\n' + tbl_header_bottom + '\n'
-    # the footer is in general the delimiter between rows, including the last one
-    tbl_footer = tbl_header_top + '\n'
-
-    tbl_body = ''
-    for row in range(0, cells.shape[0]):
-        # Pick either individual or group link
-        if isinstance(items_link, list):
-            link = items_link[row]
-        else:
-            link = items_link
-
-        tbl_body += '|' + rows_txt[row].ljust(first_col_len, ' ') + '|'
-        for col in range(0, cells.shape[1]):
-            tbl_body += format_cell_value_rst(cells[row, col], cell_len, color_scale, link) + '|'
-
-        tbl_body += '\n'
-        tbl_body += tbl_footer
-
-    return tbl_header  + tbl_body
-
-
-def build_rst_table_header_chunks(first_col_len, cell_len, columns_txt):
-    """
-    Prepare the horizontal and vertical lines in the RST headers.
-
-    @param first_col_len :: length (in characters) of the first column
-    @param cell_len :: length of all other cells
-    """
-    tbl_header_top = '+'
-    tbl_header_text = '|'
-    tbl_header_bottom = '+'
-
-    # First column in the header for the name of the test or statistics
-    tbl_header_top += '-'.ljust(first_col_len, '-') + '+'
-    tbl_header_text += ' '.ljust(first_col_len, ' ') + '|'
-    tbl_header_bottom += '='.ljust(first_col_len, '=') + '+'
-    for col_name in columns_txt:
-        tbl_header_top += '-'.ljust(cell_len, '-') + '+'
-        tbl_header_text += col_name.ljust(cell_len, ' ') + '|'
-        tbl_header_bottom += '='.ljust(cell_len, '=') + '+'
-
-    return tbl_header_top, tbl_header_text, tbl_header_bottom
-
-
-def calc_first_col_len(cell_len, rows_txt):
-    first_col_len = cell_len
-    for row_name in rows_txt:
-        name_len = len(row_name)
-        if name_len > first_col_len:
-            first_col_len = name_len
-
-    return first_col_len
-
-
-def build_items_links(comparison_type, comparison_dim, using_errors):
-    """
-    Figure out the links from rst table cells to other pages/sections of pages.
-
-    @param comparison_type :: whether this is a 'summary', or a full 'accuracy', or 'runtime' table.
-    @param comparison_dim :: dimension (accuracy / runtime)
-    @param using_errors :: whether using observational errors in cost functions
-
-    @returns :: link or links to use from table cells.
-    """
-    if 'summary' == comparison_type:
-        items_link = ['Minimizers_{0}_comparison_in_terms_of_{1}_nist_lower'.
-                      format(weighted_suffix_string(using_errors), comparison_dim),
-                      'Minimizers_{0}_comparison_in_terms_of_{1}_nist_average'.
-                      format(weighted_suffix_string(using_errors), comparison_dim),
-                      'Minimizers_{0}_comparison_in_terms_of_{1}_nist_higher'.
-                      format(weighted_suffix_string(using_errors), comparison_dim),
-                      'Minimizers_{0}_comparison_in_terms_of_{1}_cutest'.
-                      format(weighted_suffix_string(using_errors), comparison_dim),
-                      'Minimizers_{0}_comparison_in_terms_of_{1}_neutron_data'.
-                      format(weighted_suffix_string(using_errors), comparison_dim),
-                      ]
-    elif 'accuracy' == comparison_type or 'runtime' == comparison_type:
-        if using_errors:
-            items_link = 'FittingMinimizersComparisonDetailedWithWeights'
-        else:
-            items_link = 'FittingMinimizersComparisonDetailed'
-    else:
-        items_link = ''
-
-    return items_link
-
-
-def format_cell_value_rst(value, width=None, color_scale=None, items_link=None):
-    """
-    Build the content string for a table cell, adding style/color tags
-    if required.
-
-    @param value :: the value of the result
-    @param width :: the width of the longest table cell
-    @param color_scale :: the colour scale used
-    @param items_link :: the links from rst table cells to other pages/sections of pages
-    @returns :: the (formatted) contents of a cell
-
-    """
-    if not color_scale:
-        if not items_link:
-            value_text = ' {0:.4g}'.format(value)
-        else:
-            value_text = ' :ref:`{0:.4g} <{1}>`'.format(value, items_link)
-    else:
-        color = ''
-        for color_descr in color_scale:
-            if value <= color_descr[0]:
-                color = color_descr[1]
-                break
-        if not color:
-            color = color_scale[-1][1]
-        value_text = " :{0}:`{1:.4g}`".format(color, value)
-
-    if width is not None:
-        value_text = value_text.ljust(width, ' ')
-
-    return value_text
 
 
 def print_tables_simple_text(minimizers, results_per_test, accuracy_tbl, time_tbl, norm_acc_rankings):
@@ -555,3 +232,327 @@ def print_tables_simple_text(minimizers, results_per_test, accuracy_tbl, time_tb
     time_text += '\n'
 
     print(time_text)
+
+
+def build_rst_table(columns_txt, rows_txt, cells, comparison_type, comparison_dim,
+                    using_errors, color_scale=None):
+    """"
+    Builds an RST table as a string, given the list of column and row headers,
+    and a 2D numpy array with values for the cells.
+    This can be tricky/counterintuitive, see:
+    http://docutils.sourceforge.net/docs/dev/rst/problems.html
+
+    @param columns_txt :: the text for the columns, one item per column
+    @param rows_txt :: the text for the rows (will go in the leftmost column)
+    @param cells :: a 2D numpy array with as many rows as items have been given
+    in rows_txt, and as many columns as items have been given in columns_txt
+
+    @param comparison_type :: whether this is a 'summary', or a full 'accuracy', or 'runtime'
+                              table.
+    @param comparison_dim :: dimension (accuracy / runtime)
+    @param using_errors :: whether this comparison uses errors in the cost function
+    (weighted or unweighted), required to link the table properly
+
+    @param color_scale :: list with pairs of threshold value - color, to produce color
+    tags for the cells
+    """
+    columns_txt = display_name_for_minimizers(columns_txt)
+
+    items_link = build_items_links(comparison_type, comparison_dim, using_errors)
+
+    cell_len = calc_cell_len_rst_table(columns_txt, items_link, cells, color_scale)
+
+    # The first column tends to be disproportionately long if it has a link
+    first_col_len = calc_first_col_len(cell_len, rows_txt)
+
+    tbl_header_top, tbl_header_text, tbl_header_bottom = build_rst_table_header_chunks(first_col_len, cell_len,
+                                                                                       columns_txt)
+
+    tbl_header = tbl_header_top + '\n' + tbl_header_text + '\n' + tbl_header_bottom + '\n'
+    # the footer is in general the delimiter between rows, including the last one
+    tbl_footer = tbl_header_top + '\n'
+
+    tbl_body = ''
+    for row in range(0, cells.shape[0]):
+        # Pick either individual or group link
+        if isinstance(items_link, list):
+            link = items_link[row]
+        else:
+            link = items_link
+
+        tbl_body += '|' + rows_txt[row].ljust(first_col_len, ' ') + '|'
+        for col in range(0, cells.shape[1]):
+            tbl_body += format_cell_value_rst(cells[row, col], cell_len, color_scale, link) + '|'
+
+        tbl_body += '\n'
+        tbl_body += tbl_footer
+
+    return tbl_header  + tbl_body
+
+
+def save_table_to_file(table_data, errors, group_name, metric_type, file_extension):
+    """
+    Saves a group results table or overall results table to a given file type.
+
+    @param table_data :: the results table
+    @param errors :: whether to use observational errors
+    @param group_name :: name of this group of problems (example 'NIST "lower difficulty"', or
+                         'Neutron data')
+    @param metric_type :: the test type of the table data (e.g. runtime, accuracy)
+    @param file_extension :: the file type extension (e.g. html)
+    """
+    file_name = ('comparison_{weighted}_{version}_{metric_type}_{group_name}.'
+                 .format(weighted=weighted_suffix_string(errors),
+                         version=BENCHMARK_VERSION_STR, metric_type=metric_type, group_name=group_name))
+
+    if file_extension == 'html':
+        rst_content = '.. include:: ' + str(os.path.join(SCRIPT_DIR, 'color_definitions.txt'))
+        rst_content += '\n' + table_data
+        table_data = publish_string(rst_content, writer_name='html')
+
+    with open(file_name + file_extension, 'w') as tbl_file:
+        print(table_data, file=tbl_file)
+    print('Saved {file_name}{extension} to {working_directory}'.
+          format(file_name=file_name, extension=file_extension, working_directory=WORKING_DIR))
+
+
+def weighted_suffix_string(use_errors):
+    """
+    Produces a suffix weighted/unweighted. Used to generate names of
+    output files.
+    """
+    values = {True: 'weighted', False: 'unweighted'}
+    return values[use_errors]
+
+
+def build_visual_display_page(prob_results, group_name):
+    """
+    Builds a page containing details of the best fit for a problem.
+    @param prob_results:: the list of results for a problem
+    @param group_name :: the name of the group, e.g. "nist_lower"
+    """
+    # Get the best result for a group
+    gb = min((result for result in prob_results), key=lambda result: result.fit_chi2)
+    file_name = (group_name + '_' + gb.problem.name).lower()
+    wks = msapi.CreateWorkspace(OutputWorkspace=gb.problem.name, DataX=gb.problem.data_pattern_in, DataY=gb.problem.data_pattern_out)
+    # Create various page headings, ensuring the adornment is (at least) the length of the title
+    title = '=' * len(gb.problem.name) + '\n'
+    title += gb.problem.name + '\n'
+    title += '=' * len(gb.problem.name) + '\n\n'
+    data_plot = 'Plot of the data' + '\n'
+    data_plot += ('-' * len(data_plot)) + '\n\n'
+    data_plot += '.. image:: ' + file_name + '.png' + '\n\n'
+    starting_plot = 'Plot of the initial starting guess' + '\n'
+    starting_plot += ('-' * len(starting_plot)) + '\n\n'
+    starting_plot += '.. figure:: ' + '\n\n'
+    solution_plot = 'Plot of the solution found' + '\n'
+    solution_plot += ('-' * len(solution_plot)) + '\n\n'
+    solution_plot += '.. figure:: ' + '\n\n'
+    problem = 'Fit problem' + '\n'
+    problem += ('-' * len(problem)) + '\n'
+    rst_text = title + data_plot + starting_plot + solution_plot + problem
+
+    html = publish_string(rst_text, writer_name='html')
+    with open(file_name + '.' + FILENAME_EXT_TXT, 'w') as visual_rst:
+        print(html, file=visual_rst)
+        print('Saved {file_name}.{extension} to {working_directory}'.
+              format(file_name=file_name, extension=FILENAME_EXT_TXT, working_directory=WORKING_DIR))
+    with open(file_name + '.' + FILENAME_EXT_HTML, 'w') as visual_html:
+        print(html, file=visual_html)
+        print('Saved {file_name}.{extension} to {working_directory}'.
+              format(file_name=file_name, extension=FILENAME_EXT_HTML, working_directory=WORKING_DIR))
+
+    rst_link = '`<' + file_name + '.' + FILENAME_EXT_HTML + '>`_'  # `<cutest_palmer6c.dat.html>`_
+    return rst_link
+
+
+def display_name_for_minimizers(names):
+    """
+    Converts minimizer names into their "display names". For example
+    to rename DTRS to "Trust region" or similar
+
+    """
+    display_names = names
+    # Quick fix for DTRS name in version 3.8 - REMOVE
+    for idx, minimizer in enumerate(names):
+        if 'DTRS' == minimizer:
+            display_names[idx] = 'Trust Region'
+
+    return display_names
+
+
+def build_items_links(comparison_type, comparison_dim, using_errors):
+    """
+    Figure out the links from rst table cells to other pages/sections of pages.
+
+    @param comparison_type :: whether this is a 'summary', or a full 'accuracy', or 'runtime' table.
+    @param comparison_dim :: dimension (accuracy / runtime)
+    @param using_errors :: whether using observational errors in cost functions
+
+    @returns :: link or links to use from table cells.
+    """
+    if 'summary' == comparison_type:
+        items_link = ['Minimizers_{0}_comparison_in_terms_of_{1}_nist_lower'.
+                      format(weighted_suffix_string(using_errors), comparison_dim),
+                      'Minimizers_{0}_comparison_in_terms_of_{1}_nist_average'.
+                      format(weighted_suffix_string(using_errors), comparison_dim),
+                      'Minimizers_{0}_comparison_in_terms_of_{1}_nist_higher'.
+                      format(weighted_suffix_string(using_errors), comparison_dim),
+                      'Minimizers_{0}_comparison_in_terms_of_{1}_cutest'.
+                      format(weighted_suffix_string(using_errors), comparison_dim),
+                      'Minimizers_{0}_comparison_in_terms_of_{1}_neutron_data'.
+                      format(weighted_suffix_string(using_errors), comparison_dim),
+                      ]
+    elif 'accuracy' == comparison_type or 'runtime' == comparison_type:
+        if using_errors:
+            items_link = 'FittingMinimizersComparisonDetailedWithWeights'
+        else:
+            items_link = 'FittingMinimizersComparisonDetailed'
+    else:
+        items_link = ''
+
+    return items_link
+
+
+def calc_cell_len_rst_table(columns_txt, items_link, cells, color_scale=None):
+    """
+    Calculate ascii character width needed for an RST table, using the length of the longest table cell.
+
+    @param columns_txt :: list of the contents of the column headers
+    @param items_link :: the links from rst table cells to other pages/sections of pages
+    @param cells :: the values of the results
+    @param color_scale :: whether a color_scale is used or not
+    @returns :: the length of the longest cell in a table
+    """
+
+    # The length of the longest header (minimizer name)
+    max_header = len(max((col for col in columns_txt), key=len))
+    # The value of the longest (once formatted) value in the table
+    max_value = max(("%.4g" % cell for cell in np.nditer(cells)), key=len)
+    # The length of the longest link reference (angular bracket content present in summary tables)
+    max_item = max(items_link, key=len) if isinstance(items_link, list) else items_link
+    # One space on each end of a cell
+    padding = 2
+    # Set cell length equal to the length of: the longest combination of value, test name, and colour (plus padding)
+    cell_len = len(format_cell_value_rst(value=float(max_value),
+                                         color_scale=color_scale,
+                                         items_link=max_item).strip()) + padding
+    # If the header is longer than any cell's contents, i.e. is a group results table, use that length instead
+    if cell_len < max_header:
+        cell_len = max_header
+
+    return cell_len
+
+
+def calc_first_col_len(cell_len, rows_txt):
+    first_col_len = cell_len
+    for row_name in rows_txt:
+        name_len = len(row_name)
+        if name_len > first_col_len:
+            first_col_len = name_len
+
+    return first_col_len
+
+
+def build_rst_table_header_chunks(first_col_len, cell_len, columns_txt):
+    """
+    Prepare the horizontal and vertical lines in the RST headers.
+
+    @param first_col_len :: length (in characters) of the first column
+    @param cell_len :: length of all other cells
+    """
+    tbl_header_top = '+'
+    tbl_header_text = '|'
+    tbl_header_bottom = '+'
+
+    # First column in the header for the name of the test or statistics
+    tbl_header_top += '-'.ljust(first_col_len, '-') + '+'
+    tbl_header_text += ' '.ljust(first_col_len, ' ') + '|'
+    tbl_header_bottom += '='.ljust(first_col_len, '=') + '+'
+    for col_name in columns_txt:
+        tbl_header_top += '-'.ljust(cell_len, '-') + '+'
+        tbl_header_text += col_name.ljust(cell_len, ' ') + '|'
+        tbl_header_bottom += '='.ljust(cell_len, '=') + '+'
+
+    return tbl_header_top, tbl_header_text, tbl_header_bottom
+
+
+def format_cell_value_rst(value, width=None, color_scale=None, items_link=None):
+    """
+    Build the content string for a table cell, adding style/color tags
+    if required.
+
+    @param value :: the value of the result
+    @param width :: the width of the longest table cell
+    @param color_scale :: the colour scale used
+    @param items_link :: the links from rst table cells to other pages/sections of pages
+    @returns :: the (formatted) contents of a cell
+
+    """
+    if not color_scale:
+        if not items_link:
+            value_text = ' {0:.4g}'.format(value)
+        else:
+            value_text = ' :ref:`{0:.4g} <{1}>`'.format(value, items_link)
+    else:
+        color = ''
+        for color_descr in color_scale:
+            if value <= color_descr[0]:
+                color = color_descr[1]
+                break
+        if not color:
+            color = color_scale[-1][1]
+        value_text = " :{0}:`{1:.4g}`".format(color, value)
+
+    if width is not None:
+        value_text = value_text.ljust(width, ' ')
+
+    return value_text
+
+
+def print_overall_results_table(minimizers, group_results, problems, group_names, use_errors,
+                                simple_text=True, save_to_file=False):
+
+    groups_norm_acc, groups_norm_runtime = postproc.calc_summary_table(minimizers, group_results)
+
+    grp_linked_names = build_group_linked_names(group_names)
+
+    header = '**************** Accuracy ******** \n\n'
+    print(header)
+    tbl_all_summary_acc = build_rst_table(minimizers, grp_linked_names, groups_norm_acc,
+                                          comparison_type='summary', comparison_dim='accuracy',
+                                          using_errors=use_errors)
+    print(tbl_all_summary_acc)
+
+    if save_to_file:
+        save_table_to_file(tbl_all_summary_acc, use_errors, 'summary', FILENAME_SUFFIX_ACCURACY, FILENAME_EXT_TXT)
+        save_table_to_file(tbl_all_summary_acc, use_errors, 'summary', FILENAME_SUFFIX_ACCURACY, FILENAME_EXT_HTML)
+    header = '**************** Runtime ******** \n\n'
+    print (header)
+    tbl_all_summary_runtime = build_rst_table(minimizers, grp_linked_names, groups_norm_runtime,
+                                              comparison_type='summary', comparison_dim='runtime',
+                                              using_errors=use_errors)
+    if save_to_file:
+        save_table_to_file(tbl_all_summary_runtime, use_errors, 'summary', FILENAME_SUFFIX_RUNTIME, FILENAME_EXT_TXT)
+        save_table_to_file(tbl_all_summary_runtime, use_errors, 'summary', FILENAME_SUFFIX_RUNTIME, FILENAME_EXT_HTML)
+
+
+def build_group_linked_names(group_names):
+    """
+    Add a link for RST tables if there is a website or similar describing the group.
+
+    @param group_names :: names as plain text
+
+    @returns :: names with RST links if available
+    """
+    linked_names = []
+    for name in group_names:
+        # This should be tidied up. We currently don't have links for groups other than NIST
+        if 'NIST' in name:
+            linked = "`{0} <http://www.itl.nist.gov/div898/strd/nls/nls_main.shtml>`__".format(name)
+        else:
+            linked = name
+
+        linked_names.append(linked)
+
+    return linked_names

--- a/fitbenchmarking/test_result.py
+++ b/fitbenchmarking/test_result.py
@@ -29,10 +29,12 @@ class FittingTestResult(object):
         self.problem = None
         self.fit_status = None
         self.fit_chi2 = None
+
         # Workspace with data to fit
         self.fit_wks = None
         self.params = None
         self.errors = None
         self.sum_err_sq = None
+        
         # Time it took to run the Fit algorithm
         self.runtime = None

--- a/setup.py
+++ b/setup.py
@@ -6,5 +6,5 @@ setup(name='fitbenchmarking',
       url='http://github.com/mantidproject/fitbenchmarking',
       license='GPL-3.0',
       packages=find_packages(),
-      install_requires=['python-docutils'],
+      install_requires=['docutils'],
       zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -6,4 +6,5 @@ setup(name='fitbenchmarking',
       url='http://github.com/mantidproject/fitbenchmarking',
       license='GPL-3.0',
       packages=find_packages(),
+      install_requires=['python-docutils'],
       zip_safe=False)


### PR DESCRIPTION
This comes after PR #21 
This fixes #16
 
Just included install_packages=["python-docutils"] in setup.py. When users will run setup, docutils will also be installed on their machine.

To test:
1. On Ubuntu 16 make sure the package docutils is not installed
    - check /usr/lib/python2.7, if you find any folder with docutils in its name run `sudo apt remove python-docutils` in the terminal
    - check /usr/local/lib/python2.7, if you find any folder with docutils in its name run `sudo rm -r /usr/local/lib/python2.7/NameOfFolderWithDocutils`
2. Run example_runScript.py in mantidpython
    - to do this open a terminal and run `cd /opt/Mantid/bin` or wherever mantidplot is installed on your machine
    - once in the bin directory, run `./mantidpython` in terminal
    - here cd to the fitbenchmarking folder and run example_runScript.py
    - this should return an **ImportError**
3. In a normal terminal run `sudo python setup.py develop` (in the /fitbenchmarking dir)
    - make sure you have the setuptools package installed (this won't be needed by the future user)
    - to install setuptools run `sudo apt-get install python-setuptools` in the terminal
4. Close the mantidpython terminal and open it again
5. Run example_runScript.py in the new mantidpython terminal

Issue should now be fixed.
