### PR TITLE
Output nan in the table when fitting fails

### DIFF
--- a/fitbenchmarking/example_runScripts.py
+++ b/fitbenchmarking/example_runScripts.py
@@ -11,7 +11,7 @@ import results_output as fitout
 minimizers = ['BFGS', 'Conjugate gradient (Fletcher-Reeves imp.)',
               'Conjugate gradient (Polak-Ribiere imp.)',
               'Levenberg-Marquardt', 'Levenberg-MarquardtMD',
-              'Simplex', 'SteepestDescent',
+              'Simplex','SteepestDescent',
               'Trust Region', 'Damped GaussNewton']
 
 group_names = ['NIST, "lower" difficulty', 'NIST, "average" difficulty',
@@ -37,7 +37,7 @@ neutron_data_group_dirs = [os.path.join(base_problem_files_dir, 'Neutron_data')]
 muon_data_group_dir = [os.path.join(base_problem_files_dir, 'Muon_data')]
 
 # choice the data to run
-run_data = "nist"
+run_data = "neutron"
 
 if run_data == "neutron":
     problems, results_per_group = fitbk.do_fitting_benchmark(neutron_data_group_dirs=neutron_data_group_dirs,
@@ -61,7 +61,7 @@ for idx, group_results in enumerate(results_per_group):
         fitout.print_group_results_tables(minimizers, group_results, problems[idx],
                                           group_name=group_suffix_names[idx],
                                           use_errors=use_errors,
-                                          simple_text=True, rst=True, save_to_file=True, color_scale=color_scale)
+                                          simple_text=False, rst=True, save_to_file=True, color_scale=color_scale)
                                           
                                           
 header = '\n\n**************** OVERALL SUMMARY - ALL GROUPS ******** \n\n'

--- a/fitbenchmarking/fitting_benchmarking.py
+++ b/fitbenchmarking/fitting_benchmarking.py
@@ -182,9 +182,10 @@ def do_fitting_benchmark_one_problem(prob, minimizers, use_errors=True, count=0,
                     best_fit=data(minimizer_name,tmp.readX(1),tmp.readY(1))
                     min_sum_err_sq=sum_err_sq
             else:
-                sum_err_sq = float("inf")
+                sum_err_sq = float("nan")
                 print(" WARNING: no output fit workspace")
-            print("   sum sq: {0}".format(sum_err_sq))
+            print("sum sq: {0}".format(sum_err_sq))
+
             result = test_result.FittingTestResult()
             result.problem = prob
             result.fit_status = status
@@ -196,7 +197,9 @@ def do_fitting_benchmark_one_problem(prob, minimizers, use_errors=True, count=0,
             result.runtime = t_end - t_start if not np.isnan(chi2) else np.nan
             print("Result object: {0}".format(result))
             results_problem_start.append(result)
+
         results_fit_problem.append(results_problem_start)
+
         # make plots
         fig=plot()
         best_fit.markers=''
@@ -241,6 +244,7 @@ def do_fitting_benchmark_one_problem(prob, minimizers, use_errors=True, count=0,
         start_fig.labels['y']="Arbitrary units"
         title=user_func[27:-1]
         title=splitByString(title,30)
+
         # remove the extension (e.g. .nxs) if there is one
         run_ID = prob.name
         k=-1
@@ -252,6 +256,7 @@ def do_fitting_benchmark_one_problem(prob, minimizers, use_errors=True, count=0,
         start_fig.title_size=10
         fig.make_scatter_plot("Fit for "+run_ID+" "+str(count)+".pdf")
         start_fig.make_scatter_plot("start for "+run_ID+" "+str(count)+".pdf")
+
     return results_fit_problem
 
 
@@ -287,10 +292,10 @@ def run_fit(wks, prob, function, minimizer='Levenberg-Marquardt', cost_function=
 
         calc_chi2 = msapi.CalculateChiSquared(Function=function,
                                               InputWorkspace=wks, IgnoreInvalidData=ignore_invalid)
-        print("*** with minimizer {0}, calculated: chi2: {1}".format(minimizer, calc_chi2))
 
     except RuntimeError as rerr:
         print("Warning, Fit probably failed. Going on. Error: {0}".format(str(rerr)))
+        
     param_tbl = fit_result.OutputParameters
     if param_tbl:
         params = param_tbl.column(1)[:-1]

--- a/fitbenchmarking/fitting_benchmarking.py
+++ b/fitbenchmarking/fitting_benchmarking.py
@@ -113,7 +113,7 @@ def do_fitting_benchmark_group(group_name, problem_files, minimizers, use_errors
     if group_name in ['nist', 'cutest']:
         for prob_file in problem_files:
             prob = iparsing.load_nist_fitting_problem_file(prob_file)
-            
+
             print("* Testing fitting for problem definition file {0}".format(prob_file))
             print("* Testing fitting of problem {0}".format(prob.name))
 
@@ -129,10 +129,10 @@ def do_fitting_benchmark_group(group_name, problem_files, minimizers, use_errors
 
             results_prob = do_fitting_benchmark_one_problem(prob, minimizers, use_errors, count, previous_name)
             results_per_problem.extend(results_prob)
-    
+
     else:
         raise NameError("Please assign your problem group to a parser.")
-    
+
     return problems, results_per_problem
 
 
@@ -170,12 +170,10 @@ def do_fitting_benchmark_one_problem(prob, minimizers, use_errors=True, count=0,
             t_end = time.clock()
 
             print("*** with minimizer {0}, Status: {1}, chi2: {2}".format(minimizer_name, status, chi2))
-            
+
             sum_err_sq = -1
             if not status == 'failed':
                 print("   params: {0}, errors: {1}".format(params, errors))
-                def sum_of_squares(values):
-                    return np.sum(np.square(values))
                 if fit_wks:
                     sum_err_sq = sum_of_squares(fit_wks.readY(2))
                     # print " output simulated values: {0}".format(fit_wks.readY(1))
@@ -224,7 +222,7 @@ def do_fitting_benchmark_one_problem(prob, minimizers, use_errors=True, count=0,
         else:
             count =1
             previous_name=prob.name
-        
+
         #fig.labels['y']="something "
         fig.labels['title']=prob.name[:-4]+" "+str(count)
         fig.title_size=10
@@ -292,7 +290,7 @@ def run_fit(wks, prob, function, minimizer='Levenberg-Marquardt', cost_function=
                                CostFunction=cost_function,
                                IgnoreInvalidData=ignore_invalid,
                                StartX=prob.start_x, EndX=prob.end_x)
-        
+
         calc_chi2 = msapi.CalculateChiSquared(Function=function,
                                               InputWorkspace=wks, IgnoreInvalidData=ignore_invalid)
 
@@ -304,7 +302,7 @@ def run_fit(wks, prob, function, minimizer='Levenberg-Marquardt', cost_function=
     if fit_result is None:
         return 'failed', np.nan, np.nan, np.nan, np.nan
 
-    else:        
+    else:
         param_tbl = fit_result.OutputParameters
         if param_tbl:
             params = param_tbl.column(1)[:-1]
@@ -337,6 +335,10 @@ def prepare_wks_cost_function(prob, use_errors):
         cost_function = 'Unweighted least squares'
 
     return wks, cost_function
+
+
+def sum_of_squares(values):
+    return np.sum(np.square(values))
 
 
 def splitByString(name,min_length,loop=0,splitter=0):

--- a/fitbenchmarking/post_processing.py
+++ b/fitbenchmarking/post_processing.py
@@ -39,6 +39,7 @@ def calc_accuracy_runtime_tbls(results_per_test, minimizers):
     num_minimizers = len(minimizers)
     accuracy_tbl = np.zeros((num_tests, num_minimizers))
     time_tbl = np.zeros((num_tests, num_minimizers))
+    
     for test_idx in range(0, num_tests):
         for minimiz_idx in range(0, num_minimizers):
             accuracy_tbl[test_idx, minimiz_idx] = results_per_test[test_idx][minimiz_idx].sum_err_sq


### PR DESCRIPTION
This comes after #18 
The ValueError that is raised by the Simplex minimizer in problem WISH17701 panel 103 tube 3 calibration, peak 9 1 is now caught and a nan value is outputted in the table.

To test:

1. In example_runScript.py make sure
    - minimizers contains 'Simplex'
    - run_data = 'neutron'
2. Run example_runScript.py in the mantidpython terminal
3. Check the table comparison_weighted_v3.8_acc_nist_lower.html under column Simplex, last row, should display nan

Notes: 
- The table name is wrong, this is a known issue, changing it to neutron causes a crash #22 .
- This only catches RuntimeErrors and ValueErrors, if the fit algorithm returns any other kind of error, the problem is still there. Doing an except that catches everything is generally bad practice so I refrained from doing so here. In this case, other kind of error should be added as they are discovered.