### PR TITLE
Code now considers only one column when parsing nist file

### DIFF
--- a/fitbenchmarking/input_parsing.py
+++ b/fitbenchmarking/input_parsing.py
@@ -63,7 +63,7 @@ def parse_nist_file(spec_file):
                         format(prob.name, prob.name.lower()))
     prob.equation = parsed_eq
     prob.starting_values = starting_values
-    prob.data_pattern_in = data_pattern[:, 1:]
+    prob.data_pattern_in = data_pattern[:, 1]
     prob.data_pattern_out = data_pattern[:, 0]
     prob.ref_residual_sum_sq = residual_sum_sq
 


### PR DESCRIPTION
Fixes #37

#### To test:

1. Make sure that in example_runScripts.py `run_data` is set to "nist".
2. Run example_runScripts.py in the mantidpython console.
3. Compare the results with the output you get from following the same steps in master branch.