### PR TITLE
Fake observational errors now can deal with negative values

### DIFF
--- a/fitbenchmarking/fitting_benchmarking.py
+++ b/fitbenchmarking/fitting_benchmarking.py
@@ -340,8 +340,10 @@ def prepare_wks_cost_function(prob, use_errors):
     if use_errors:
         data_e = None
         if prob.data_pattern_obs_errors is None:
-            # Fake observational errors
-            data_e = np.sqrt(prob.data_pattern_out)
+            # Fake observational errors - no correct answer (since we do not know
+            # where the y values come from), but we are taking
+            # the errrors to be the square root of the absolute y value
+            data_e = np.sqrt(abs(prob.data_pattern_out))
         else:
             data_e = prob.data_pattern_obs_errors
 


### PR DESCRIPTION
Fixes #50

#### Description of Work
Faking observational errors now takes the square root of the absolute value of y data.

#### Testing Instructions
1. In `example_runScript.py` make sure that `run_data = "nist"`.
2. In the mantidpython console, run `example_runScript.py`.
3. Check the acc_high_difficulty nist table that is produced, the Bennett5 rows should now contain numbers instead of `nans`.
