### PR TITLE
Fixed build_visual_display_page producing a crash

### DIFF
--- a/fitbenchmarking/example_runScripts.py
+++ b/fitbenchmarking/example_runScripts.py
@@ -12,8 +12,6 @@ minimizers = ['BFGS', 'Conjugate gradient (Fletcher-Reeves imp.)',
               'Simplex','SteepestDescent',
               'Trust Region']
 
-group_names = ['NIST, "lower" difficulty', 'NIST, "average" difficulty',
-               'NIST, "higher" difficulty', "CUTEst", "Neutron data"]
 group_suffix_names = ['nist_lower', 'nist_average', 'nist_higher', 'cutest', 'neutron_data']
 color_scale = [(1.1, 'ranking-top-1'),
                (1.33, 'ranking-top-2'),
@@ -37,16 +35,21 @@ muon_data_group_dir = [os.path.join(base_problem_files_dir, 'Muon_data')]
 run_data = "neutron"
 
 if run_data == "neutron":
+    group_suffix_names = ['neutron_data']
+    group_names = ["Neutron data"]
     problems, results_per_group = fitBenchmarking(neutron_data_group_dirs=neutron_data_group_dirs,
-                                                             minimizers=minimizers, use_errors=use_errors)
+                                                  minimizers=minimizers, use_errors=use_errors)
 elif run_data == "muon":
     group_names = ['MUON']
     group_suffix_names = ['MUON']
     problems, results_per_group = fitBenchmarking(muon_data_group_dir=muon_data_group_dir,
-                                                             minimizers=minimizers, use_errors=use_errors)
+                                                  minimizers=minimizers, use_errors=use_errors)
 elif run_data == "nist":
+    group_names = ['NIST, "lower" difficulty', 'NIST, "average" difficulty',
+                   'NIST, "higher" difficulty']
+    group_suffix_names = ['nist_lower', 'nist_average', 'nist_higher']
     problems, results_per_group = fitBenchmarking(nist_group_dir=nist_group_dir,
-                                                             minimizers=minimizers, use_errors=use_errors)
+                                                  minimizers=minimizers, use_errors=use_errors)
 
 for idx, group_results in enumerate(results_per_group):
     printTables(minimizers, group_results, problems[idx],

--- a/fitbenchmarking/results_output.py
+++ b/fitbenchmarking/results_output.py
@@ -146,9 +146,11 @@ def build_visual_display_page(prob_results, group_name):
     @param group_name :: the name of the group, e.g. "nist_lower"
     """
     # Get the best result for a group
-    gb = min((result for result in prob_results), key=lambda result: result.fit_chi2)
-    file_name = (group_name + '_' + gb.problem.name).lower()
-    wks = msapi.CreateWorkspace(OutputWorkspace=gb.problem.name, DataX=gb.problem.data_pattern_in, DataY=gb.problem.data_pattern_out)
+    gb = min((result for result in prob_results), key=lambda result: result.fit_chi_sq)
+    no_commas_problem_name = gb.problem.name.replace(',', '')
+    problem_name = no_commas_problem_name.replace(' ','_')
+
+    file_name = (group_name + '_' + problem_name).lower()
 
     # Create various page headings, ensuring the adornment is (at least) the length of the title
     title = '=' * len(gb.problem.name) + '\n'
@@ -177,7 +179,9 @@ def build_visual_display_page(prob_results, group_name):
         print('Saved {file_name}.{extension} to {working_directory}'.
               format(file_name=file_name, extension=FILENAME_EXT_HTML, working_directory=WORKING_DIR))
 
+
     rst_link = '`<' + file_name + '.' + FILENAME_EXT_HTML + '>`_'  # `<cutest_palmer6c.dat.html>`_
+
     return rst_link
 
 


### PR DESCRIPTION
#### Description of Work

Fixes #22
Inside build_visual_display_page, a workspace was repeatedly created which apparently produces a crash. The workspace was not used anywhere so simply deleting that line solved the issue.


#### Testing Instructions

1. In `example_runScript.py` make sure that `run_data = "neutron"`.
2. Run `example_runScript.py` in the mantidpython console.
3. It should run smoothly now. Additionally, tables are created which link to the visual display pages.

**Note:** Visual display pages are broken. This is a known issue #
 