### PR TITLE
Run all tests at once added

### DIFF
--- a/fitbenchmarking/example_runScripts.py
+++ b/fitbenchmarking/example_runScripts.py
@@ -60,6 +60,10 @@ for run_data in ["neutron", "nist"]:
                                                       minimizers=minimizers, use_errors=use_errors,
                                                       results_dir=results_dir)
 
+    else:
+        raise RuntimeError("Invalid run_data, please check if the array"
+                            "contains the correct names!")
+
     for idx, group_results in enumerate(results_per_group):
         printTables(minimizers, group_results, problems[idx],
                     group_name=group_suffix_names[idx],

--- a/fitbenchmarking/example_runScripts.py
+++ b/fitbenchmarking/example_runScripts.py
@@ -2,6 +2,9 @@
 # fit problems
 
 import os
+import sys
+import fitting_benchmarking
+import results_output
 from fitting_benchmarking import do_fitting_benchmark as fitBenchmarking
 from results_output import print_group_results_tables as printTables
 
@@ -38,6 +41,7 @@ muon_data_group_dir = [os.path.join(base_problem_files_dir, 'Muon_data')]
 # When specifying a results_dir, please GIVE THE FULL PATH
 results_dir = None
 
+
 for run_data in ["neutron", "nist"]:
 
     if run_data == "neutron":
@@ -62,3 +66,5 @@ for run_data in ["neutron", "nist"]:
                     rst=True, save_to_file=True, color_scale=color_scale,
                     results_dir=results_dir)
 
+    reload(fitting_benchmarking)
+    reload(results_output)

--- a/fitbenchmarking/example_runScripts.py
+++ b/fitbenchmarking/example_runScripts.py
@@ -3,8 +3,7 @@
 
 import os
 import sys
-import fitting_benchmarking
-import results_output
+sys.setrecursionlimit(10000)
 from fitting_benchmarking import do_fitting_benchmark as fitBenchmarking
 from results_output import print_group_results_tables as printTables
 
@@ -65,6 +64,3 @@ for run_data in ["neutron", "nist"]:
                     use_errors=use_errors,
                     rst=True, save_to_file=True, color_scale=color_scale,
                     results_dir=results_dir)
-
-    reload(fitting_benchmarking)
-    reload(results_output)

--- a/fitbenchmarking/example_runScripts.py
+++ b/fitbenchmarking/example_runScripts.py
@@ -1,6 +1,8 @@
 # script for running fit benchmarking and comparising the relative performance of local minimzers on
 # fit problems
 
+# sys recursion limit 10000 is needed to avoid reaching the maximum recursion
+# depth when running all the problems (this produces a RuntimeError)
 import os
 import sys
 sys.setrecursionlimit(10000)

--- a/fitbenchmarking/example_runScripts.py
+++ b/fitbenchmarking/example_runScripts.py
@@ -38,33 +38,27 @@ muon_data_group_dir = [os.path.join(base_problem_files_dir, 'Muon_data')]
 # When specifying a results_dir, please GIVE THE FULL PATH
 results_dir = None
 
-# choice the data to run
-run_data = "neutron"
+for run_data in ["neutron", "nist"]:
 
-if run_data == "neutron":
-    group_suffix_names = ['neutron_data']
-    group_names = ["Neutron data"]
-    problems, results_per_group = fitBenchmarking(neutron_data_group_dirs=neutron_data_group_dirs,
-                                                  minimizers=minimizers, use_errors=use_errors,
-                                                  results_dir=results_dir)
-elif run_data == "muon":
-    group_names = ['MUON']
-    group_suffix_names = ['MUON']
-    problems, results_per_group = fitBenchmarking(muon_data_group_dir=muon_data_group_dir,
-                                                  minimizers=minimizers, use_errors=use_errors)
-    
-elif run_data == "nist":
-    group_names = ['NIST, "lower" difficulty', 'NIST, "average" difficulty',
-                   'NIST, "higher" difficulty']
-    group_suffix_names = ['nist_lower', 'nist_average', 'nist_higher']
-    problems, results_per_group = fitBenchmarking(nist_group_dir=nist_group_dir,
-                                                  minimizers=minimizers, use_errors=use_errors,
-                                                  results_dir=results_dir)
+    if run_data == "neutron":
+        group_suffix_names = ['neutron_data']
+        group_names = ["Neutron data"]
+        problems, results_per_group = fitBenchmarking(neutron_data_group_dirs=neutron_data_group_dirs,
+                                                      minimizers=minimizers, use_errors=use_errors,
+                                                      results_dir=results_dir)
 
-for idx, group_results in enumerate(results_per_group):
-    printTables(minimizers, group_results, problems[idx],
-                group_name=group_suffix_names[idx],
-                use_errors=use_errors,
-                rst=True, save_to_file=True, color_scale=color_scale,
-                results_dir=results_dir)
+    elif run_data == "nist":
+        group_names = ['NIST, "lower" difficulty', 'NIST, "average" difficulty',
+                       'NIST, "higher" difficulty']
+        group_suffix_names = ['nist_lower', 'nist_average', 'nist_higher']
+        problems, results_per_group = fitBenchmarking(nist_group_dir=nist_group_dir,
+                                                      minimizers=minimizers, use_errors=use_errors,
+                                                      results_dir=results_dir)
+
+    for idx, group_results in enumerate(results_per_group):
+        printTables(minimizers, group_results, problems[idx],
+                    group_name=group_suffix_names[idx],
+                    use_errors=use_errors,
+                    rst=True, save_to_file=True, color_scale=color_scale,
+                    results_dir=results_dir)
 

--- a/fitbenchmarking/fitting_benchmarking.py
+++ b/fitbenchmarking/fitting_benchmarking.py
@@ -69,7 +69,7 @@ def do_fitting_benchmark(nist_group_dir=None, cutest_group_dir=None, neutron_dat
     if not os.path.exists(results_dir):
         os.makedirs(results_dir)
 
-    empty_contents_of_folder(results_dir)
+
     print("***** SAVING RESULTS IN DIRECTORY {0} *****".format(results_dir))
 
     if nist_group_dir:
@@ -86,7 +86,13 @@ def do_fitting_benchmark(nist_group_dir=None, cutest_group_dir=None, neutron_dat
 
     for group_name in problem_groups:
         group_results_dir = os.path.join(results_dir, group_name)
-        os.makedirs(group_results_dir)
+
+        if os.path.exists(group_results_dir):
+            empty_contents_of_folder(group_results_dir)
+        else:
+            os.makedirs(group_results_dir)
+
+
         prob_results = [do_fitting_benchmark_group(group_name, group_results_dir, problem_block,
                                                    minimizers, use_errors=use_errors)
                         for problem_block in problem_groups[group_name]]

--- a/fitbenchmarking/input_parsing.py
+++ b/fitbenchmarking/input_parsing.py
@@ -57,7 +57,7 @@ def load_nist_fitting_problem_file(problem_filename):
         elif not residual_sum_sq:
             raise RuntimeError('Could not find the residual sum sq after parsing the lines of this file: {0}'.
                                format(spec_file.name))
-            
+
         data_pattern = parse_data_pattern(data_pattern_text)
         parsed_eq = parse_equation(equation_text)
 
@@ -68,8 +68,8 @@ def load_nist_fitting_problem_file(problem_filename):
                             format(name_without_ext, name_without_ext.lower()))
         prob.equation = parsed_eq
         prob.starting_values = starting_values
-        prob.data_pattern_in = data_pattern[:, 1]
-        prob.data_pattern_out = data_pattern[:, 0]
+        prob.data_y = data_pattern[:, 1]
+        prob.data_x = data_pattern[:, 0]
         prob.ref_residual_sum_sq = residual_sum_sq
 
         return prob


### PR DESCRIPTION
#### Description of Work

Fixes #55
Changed `example_runScript` such that it now runs all tests at once.


#### Testing Instructions

1. Run `example_runScript.py` in the mantidpython console.
2. Check if all the output is in the results folder.

**Note:** This was giving an error after completing execution: `RuntimeError maximum recursion depth reached` so I increased the recursion depth here:
https://github.com/mantidproject/fitbenchmarking/blob/acf175d8f33b932b73a653eef98ce6d0d6cb341a/fitbenchmarking/example_runScripts.py#L5-L6
I have not found any other way that fixes the problem.
