### PR TITLE
Created visual display page folder in new dir structure

### DIFF
--- a/example_scripts/example_runScripts.py
+++ b/example_scripts/example_runScripts.py
@@ -53,17 +53,17 @@ for run_data in ["neutron", "nist"]:
     if run_data == "neutron":
         group_suffix_names = ['neutron_data']
         group_names = ["Neutron data"]
-        problems, results_per_group = fitBenchmarking(neutron_data_group_dirs=neutron_data_group_dirs,
-                                                      minimizers=minimizers, use_errors=use_errors,
-                                                      results_dir=results_dir)
+        problems, results_per_group, results_dir = fitBenchmarking(neutron_data_group_dirs=neutron_data_group_dirs,
+                                                                   minimizers=minimizers, use_errors=use_errors,
+                                                                   results_dir=results_dir)
 
     elif run_data == "nist":
         group_names = ['NIST, "lower" difficulty', 'NIST, "average" difficulty',
                        'NIST, "higher" difficulty']
         group_suffix_names = ['nist_lower', 'nist_average', 'nist_higher']
-        problems, results_per_group = fitBenchmarking(nist_group_dir=nist_group_dir,
-                                                      minimizers=minimizers, use_errors=use_errors,
-                                                      results_dir=results_dir)
+        problems, results_per_group, results_dir = fitBenchmarking(nist_group_dir=nist_group_dir,
+                                                                   minimizers=minimizers, use_errors=use_errors,
+                                                                   results_dir=results_dir)
 
     else:
         raise RuntimeError("Invalid run_data, please check if the array"

--- a/fitbenchmarking/example_runScripts.py
+++ b/fitbenchmarking/example_runScripts.py
@@ -44,22 +44,25 @@ run_data = "neutron"
 if run_data == "neutron":
     group_suffix_names = ['neutron_data']
     group_names = ["Neutron data"]
-    problems, results_per_group = fitBenchmarking(neutron_data_group_dirs=neutron_data_group_dirs,
-                                                  minimizers=minimizers, use_errors=use_errors,
-                                                  results_dir=results_dir)
+    (problems, results_per_group,
+     results_dir) = fitBenchmarking(neutron_data_group_dirs=neutron_data_group_dirs,
+                                    minimizers=minimizers, use_errors=use_errors,
+                                    results_dir=results_dir)
 elif run_data == "muon":
     group_names = ['MUON']
     group_suffix_names = ['MUON']
-    problems, results_per_group = fitBenchmarking(muon_data_group_dir=muon_data_group_dir,
-                                                  minimizers=minimizers, use_errors=use_errors)
-    
+    (problems, results_per_group,
+     results_dir) = fitBenchmarking(muon_data_group_dir=muon_data_group_dir,
+                                    minimizers=minimizers, use_errors=use_errors,
+                                    results_dir=results_dir)
 elif run_data == "nist":
     group_names = ['NIST, "lower" difficulty', 'NIST, "average" difficulty',
                    'NIST, "higher" difficulty']
     group_suffix_names = ['nist_lower', 'nist_average', 'nist_higher']
-    problems, results_per_group = fitBenchmarking(nist_group_dir=nist_group_dir,
-                                                  minimizers=minimizers, use_errors=use_errors,
-                                                  results_dir=results_dir)
+    (problems, results_per_group,
+     results_dir) = fitBenchmarking(nist_group_dir=nist_group_dir,
+                                    minimizers=minimizers, use_errors=use_errors,
+                                    results_dir=results_dir)
 
 for idx, group_results in enumerate(results_per_group):
     printTables(minimizers, group_results, problems[idx],

--- a/fitbenchmarking/fitting_benchmarking.py
+++ b/fitbenchmarking/fitting_benchmarking.py
@@ -227,8 +227,8 @@ def make_plots(prob, visuals_dir, best_fit, wks, previous_name, count, user_func
     '''
     if "neutron" in visuals_dir:
         support_pages_dir = os.path.join(visuals_dir, "tables", "support_pages")
-        if not os.path.exists(VDPage_dir):
-            os.makedirs(VDPage_dir)
+        if not os.path.exists(support_pages_dir):
+            os.makedirs(support_pages_dir)
         visuals_dir = support_pages_dir
 
     figures_dir = os.path.join(visuals_dir, "figures")

--- a/fitbenchmarking/fitting_benchmarking.py
+++ b/fitbenchmarking/fitting_benchmarking.py
@@ -96,7 +96,7 @@ def do_fitting_benchmark(nist_group_dir=None, cutest_group_dir=None, neutron_dat
     if len(probs) != len(results):
         raise RuntimeError('probs : {0}, prob_results: {1}'.format(len(probs), len(results)))
 
-    return probs, results
+    return probs, results, results_dir
 
 
 def do_fitting_benchmark_group(group_name, group_results_dir, problem_files, minimizers, use_errors=True):
@@ -217,7 +217,7 @@ def do_fitting_benchmark_one_problem(prob, group_results_dir, minimizers, use_er
     return results_fit_problem
 
 
-def make_plots(prob, group_results_dir, best_fit, wks, previous_name, count, user_func):
+def make_plots(prob, visuals_dir, best_fit, wks, previous_name, count, user_func):
     '''
     Makes a plot of the best fit considering multiple starting points of a
     problem.
@@ -229,8 +229,14 @@ def make_plots(prob, group_results_dir, best_fit, wks, previous_name, count, use
     @param count :: number of different starting points for one problem
     @param user_func :: fitting function
     '''
+    if "neutron" in visuals_dir:
+        VDPage_dir = os.path.join(visuals_dir, "VDPages")
+        if not os.path.exists(VDPage_dir):
+            os.makedirs(VDPage_dir)
 
-    figures_dir = os.path.join(group_results_dir, "Figures")
+        visuals_dir = VDPage_dir
+
+    figures_dir = os.path.join(visuals_dir, "Figures")
     if not os.path.exists(figures_dir):
         os.makedirs(figures_dir)
 

--- a/fitbenchmarking/fitting_benchmarking.py
+++ b/fitbenchmarking/fitting_benchmarking.py
@@ -226,10 +226,10 @@ def make_plots(prob, visuals_dir, best_fit, wks, previous_name, count, user_func
     @param user_func :: fitting function
     '''
     if "neutron" in visuals_dir:
-        VDPage_dir = os.path.join(visuals_dir, "tables", "support_pages")
+        support_pages_dir = os.path.join(visuals_dir, "tables", "support_pages")
         if not os.path.exists(VDPage_dir):
             os.makedirs(VDPage_dir)
-        visuals_dir = VDPage_dir
+        visuals_dir = support_pages_dir
 
     figures_dir = os.path.join(visuals_dir, "figures")
 

--- a/fitbenchmarking/fitting_benchmarking.py
+++ b/fitbenchmarking/fitting_benchmarking.py
@@ -226,12 +226,12 @@ def make_plots(prob, visuals_dir, best_fit, wks, previous_name, count, user_func
     @param user_func :: fitting function
     '''
     if "neutron" in visuals_dir:
-        VDPage_dir = os.path.join(visuals_dir, "VDPages")
+        VDPage_dir = os.path.join(visuals_dir, "tables", "support_pages")
         if not os.path.exists(VDPage_dir):
             os.makedirs(VDPage_dir)
         visuals_dir = VDPage_dir
 
-    figures_dir = os.path.join(visuals_dir, "Figures")
+    figures_dir = os.path.join(visuals_dir, "figures")
 
     if not os.path.exists(figures_dir):
         os.makedirs(figures_dir)

--- a/fitbenchmarking/results_output.py
+++ b/fitbenchmarking/results_output.py
@@ -74,9 +74,10 @@ def print_group_results_tables(minimizers, results_per_test, problems_obj, group
                           at the moment).
     """
 
-    tables_dir = make_results_directory(results_dir, group_name)
+    tables_dir = make_result_tables_directory(results_dir, group_name)
+    VDpages_dir = make_visual_display_pages_dir(results_dir, group_name)
 
-    linked_problems = build_indiv_linked_problems(results_per_test, group_name)
+    linked_problems = build_indiv_linked_problems(results_per_test, group_name, VDpages_dir)
     accuracy_tbl, runtime_tbl = postproc.calc_accuracy_runtime_tbls(results_per_test, minimizers)
     norm_acc_rankings, norm_runtimes, summary_cells_acc, summary_cells_runtime = \
         postproc.calc_norm_summary_tables(accuracy_tbl, runtime_tbl)
@@ -106,7 +107,7 @@ def print_group_results_tables(minimizers, results_per_test, problems_obj, group
 
 
 
-def build_indiv_linked_problems(results_per_test, group_name):
+def build_indiv_linked_problems(results_per_test, group_name, VDpage_results_dir):
     """
     Makes a list of linked problem names which would be used for the
     rows of the first column of the tables of individual results.
@@ -136,26 +137,27 @@ def build_indiv_linked_problems(results_per_test, group_name):
 
             prev_name = name
             name_index = name + ' ' + str(prob_count)
-            name += ' ' + build_visual_display_page(prob_results, group_name)
+            name += ' ' + build_visual_display_page(prob_results, group_name, VDpage_results_dir)
             linked_problems.append(name)
 
     return linked_problems
 
 
-def build_visual_display_page(prob_results, group_name):
+def build_visual_display_page(prob_results, group_name, VDpage_results_dir):
     """
     Builds a page containing details of the best fit for a problem.
     @param prob_results:: the list of results for a problem
     @param group_name :: the name of the group, e.g. "nist_lower"
     """
-    
+
     # Get the best result for a group
     gb = min((result for result in prob_results), key=lambda result: result.fit_chi_sq)
     no_commas_problem_name = gb.problem.name.replace(',', '')
     problem_name = no_commas_problem_name.replace(' ','_')
 
     file_name = (group_name + '_' + problem_name).lower()
-    
+    file_name = os.path.join(VDpage_results_dir, file_name)
+
     # Create various page headings, ensuring the adornment is (at least) the length of the title
     title = '=' * len(gb.problem.name) + '\n'
     title += gb.problem.name + '\n'
@@ -183,8 +185,9 @@ def build_visual_display_page(prob_results, group_name):
         print('Saved {file_name}.{extension} to {working_directory}'.
               format(file_name=file_name, extension=FILENAME_EXT_HTML, working_directory=WORKING_DIR))
 
+    file_name = file_name.replace("\\", "\\\\")
 
-    rst_link = '`<' + file_name + '.' + FILENAME_EXT_HTML + '>`_'  # `<cutest_palmer6c.dat.html>`_
+    rst_link = "`<" + file_name + "." + FILENAME_EXT_HTML + ">`_"  # `<cutest_palmer6c.dat.html>`_
 
     return rst_link
 
@@ -425,7 +428,7 @@ def weighted_suffix_string(use_errors):
     return values[use_errors]
 
 
-def make_results_directory(results_dir, group_name):
+def make_result_tables_directory(results_dir, group_name):
 
     current_dir = os.path.dirname(os.path.realpath(__file__))
     if results_dir is None:
@@ -433,13 +436,35 @@ def make_results_directory(results_dir, group_name):
 
     if 'nist' in group_name:
         group_results_dir = os.path.join(results_dir, 'nist')
+        if not os.path.exists(group_results_dir):
+            os.makedirs(group_results_dir)
         tables_dir = os.path.join(group_results_dir, "Tables", group_name)
 
     elif 'neutron' in group_name:
         group_results_dir = os.path.join(results_dir, 'neutron')
+        if not os.path.exists(group_results_dir):
+            os.makedirs(group_results_dir)
         tables_dir = os.path.join(group_results_dir, "Tables")
 
     if not os.path.exists(tables_dir):
         os.makedirs(tables_dir)
 
     return tables_dir
+
+def make_visual_display_pages_dir(results_dir, group_name):
+
+    current_dir = os.path.dirname(os.path.realpath(__file__))
+    if results_dir is None:
+        results_dir = os.path.join(current_dir, "results")
+
+    if 'neutron' in group_name:
+        group_results_dir = os.path.join(results_dir, 'neutron')
+        if not os.path.exists(group_results_dir):
+            os.makedirs(group_results_dir)
+        VDpages_dir = os.path.join(group_results_dir, "VDPages")
+
+    if not os.path.exists(VDpages_dir):
+        os.makedirs(VDpages_dir)
+
+    return VDpages_dir
+

--- a/fitbenchmarking/results_output.py
+++ b/fitbenchmarking/results_output.py
@@ -73,11 +73,9 @@ def print_group_results_tables(minimizers, results_per_test, problems_obj, group
                           must be consistent with the style sheet used in the documentation pages (5
                           at the moment).
     """
-
     tables_dir = make_result_tables_directory(results_dir, group_name)
-    VDpages_dir = make_visual_display_pages_dir(results_dir, group_name)
 
-    linked_problems = build_indiv_linked_problems(results_per_test, group_name, VDpages_dir)
+    linked_problems = build_indiv_linked_problems(results_per_test, group_name, results_dir)
     accuracy_tbl, runtime_tbl = postproc.calc_accuracy_runtime_tbls(results_per_test, minimizers)
     norm_acc_rankings, norm_runtimes, summary_cells_acc, summary_cells_runtime = \
         postproc.calc_norm_summary_tables(accuracy_tbl, runtime_tbl)
@@ -107,7 +105,7 @@ def print_group_results_tables(minimizers, results_per_test, problems_obj, group
 
 
 
-def build_indiv_linked_problems(results_per_test, group_name, VDpage_results_dir):
+def build_indiv_linked_problems(results_per_test, group_name, results_dir):
     """
     Makes a list of linked problem names which would be used for the
     rows of the first column of the tables of individual results.
@@ -137,26 +135,32 @@ def build_indiv_linked_problems(results_per_test, group_name, VDpage_results_dir
 
             prev_name = name
             name_index = name + ' ' + str(prob_count)
-            name += ' ' + build_visual_display_page(prob_results, group_name, VDpage_results_dir)
+            name = '`' + name + ' ' + build_visual_display_page(prob_results, group_name, results_dir)
             linked_problems.append(name)
 
     return linked_problems
 
 
-def build_visual_display_page(prob_results, group_name, VDpage_results_dir):
+def build_visual_display_page(prob_results, group_name, results_dir):
     """
     Builds a page containing details of the best fit for a problem.
     @param prob_results:: the list of results for a problem
     @param group_name :: the name of the group, e.g. "nist_lower"
     """
 
+    # Directory that holds all the visual display pages
+    VDPages_dir = os.path.join(results_dir, "neutron", "VDPages")
+
     # Get the best result for a group
     gb = min((result for result in prob_results), key=lambda result: result.fit_chi_sq)
-    no_commas_problem_name = gb.problem.name.replace(',', '')
-    problem_name = no_commas_problem_name.replace(' ','_')
+    commaless_problem_name = gb.problem.name.replace(',', '')
+    problem_name = commaless_problem_name.replace(' ','_')
 
     file_name = (group_name + '_' + problem_name).lower()
-    file_name = os.path.join(VDpage_results_dir, file_name)
+    file_name = os.path.join(VDPages_dir, file_name)
+
+    rst_file_name = file_name.replace('\\', '/')
+    rst_link = "<file:///" +'' + rst_file_name + "." + FILENAME_EXT_HTML + ">`__"
 
     # Create various page headings, ensuring the adornment is (at least) the length of the title
     title = '=' * len(gb.problem.name) + '\n'
@@ -184,10 +188,6 @@ def build_visual_display_page(prob_results, group_name, VDpage_results_dir):
         print(html, file=visual_html)
         print('Saved {file_name}.{extension} to {working_directory}'.
               format(file_name=file_name, extension=FILENAME_EXT_HTML, working_directory=WORKING_DIR))
-
-    file_name = file_name.replace("\\", "\\\\")
-
-    rst_link = "`<" + file_name + "." + FILENAME_EXT_HTML + ">`_"  # `<cutest_palmer6c.dat.html>`_
 
     return rst_link
 
@@ -430,10 +430,6 @@ def weighted_suffix_string(use_errors):
 
 def make_result_tables_directory(results_dir, group_name):
 
-    current_dir = os.path.dirname(os.path.realpath(__file__))
-    if results_dir is None:
-        results_dir = os.path.join(current_dir, "results")
-
     if 'nist' in group_name:
         group_results_dir = os.path.join(results_dir, 'nist')
         if not os.path.exists(group_results_dir):
@@ -450,21 +446,3 @@ def make_result_tables_directory(results_dir, group_name):
         os.makedirs(tables_dir)
 
     return tables_dir
-
-def make_visual_display_pages_dir(results_dir, group_name):
-
-    current_dir = os.path.dirname(os.path.realpath(__file__))
-    if results_dir is None:
-        results_dir = os.path.join(current_dir, "results")
-
-    if 'neutron' in group_name:
-        group_results_dir = os.path.join(results_dir, 'neutron')
-        if not os.path.exists(group_results_dir):
-            os.makedirs(group_results_dir)
-        VDpages_dir = os.path.join(group_results_dir, "VDPages")
-
-    if not os.path.exists(VDpages_dir):
-        os.makedirs(VDpages_dir)
-
-    return VDpages_dir
-

--- a/fitbenchmarking/results_output.py
+++ b/fitbenchmarking/results_output.py
@@ -153,7 +153,8 @@ def build_visual_display_page(prob_results, group_name, results_dir):
     """
 
     # Directory that holds all the visual display pages
-    VDPages_dir = os.path.join(results_dir, "neutron", "VDPages")
+    VDPages_dir = os.path.join(results_dir, "neutron", "tables",
+                               "support_pages")
 
     # Get the best result for a group
     gb = min((result for result in prob_results), key=lambda result: result.fit_chi_sq)
@@ -444,13 +445,13 @@ def make_result_tables_directory(results_dir, group_name):
         group_results_dir = os.path.join(results_dir, 'nist')
         if not os.path.exists(group_results_dir):
             os.makedirs(group_results_dir)
-        tables_dir = os.path.join(group_results_dir, "Tables", group_name)
+        tables_dir = os.path.join(group_results_dir, "tables", group_name)
 
     elif 'neutron' in group_name:
         group_results_dir = os.path.join(results_dir, 'neutron')
         if not os.path.exists(group_results_dir):
             os.makedirs(group_results_dir)
-        tables_dir = os.path.join(group_results_dir, "Tables")
+        tables_dir = os.path.join(group_results_dir, "tables")
 
     if not os.path.exists(tables_dir):
         os.makedirs(tables_dir)

--- a/fitbenchmarking/results_output.py
+++ b/fitbenchmarking/results_output.py
@@ -153,8 +153,8 @@ def build_visual_display_page(prob_results, group_name, results_dir):
     """
 
     # Directory that holds all the visual display pages
-    VDPages_dir = os.path.join(results_dir, "neutron", "tables",
-                               "support_pages")
+    support_pages_dir = os.path.join(results_dir, "neutron", "tables",
+                                     "support_pages")
 
     # Get the best result for a group
     gb = min((result for result in prob_results), key=lambda result: result.fit_chi_sq)
@@ -162,7 +162,7 @@ def build_visual_display_page(prob_results, group_name, results_dir):
     problem_name = commaless_problem_name.replace(' ','_')
 
     file_name = (group_name + '_' + problem_name).lower()
-    file_name = os.path.join(VDPages_dir, file_name)
+    file_name = os.path.join(support_pages_dir, file_name)
 
     rst_file_name = file_name.replace('\\', '/')
     rst_link = "<file:///" +'' + rst_file_name + "." + FILENAME_EXT_HTML + ">`__"


### PR DESCRIPTION
#### Description of Work

Fixes #69 
Visual display pages now reside in `/fitbenchmarking/fitbenchmarking/results/neutron/VDPages/` and the tables link to them correctly.

#### Testing Instructions

1. Run `example_runScripts.py` in the mantidpython console.
2. Check if the links in the tables available at `/fitbenchmarking/fitbenchmarking/results/neutron/Tables/` point to the correct VDpages

**Note:** VDpages are still broken for the time. They will be fixed in #64 .