### PR TITLE
Fixed visual display pages

### DIFF
--- a/fitbenchmarking/example_runScripts.py
+++ b/fitbenchmarking/example_runScripts.py
@@ -49,7 +49,7 @@ for run_data in ["neutron", "nist"]:
     if run_data == "neutron":
         group_suffix_names = ['neutron_data']
         group_names = ["Neutron data"]
-        problems, results_per_group = fitBenchmarking(neutron_data_group_dirs=neutron_data_group_dirs,
+        problems, results_per_group, results_dir = fitBenchmarking(neutron_data_group_dirs=neutron_data_group_dirs,
                                                       minimizers=minimizers, use_errors=use_errors,
                                                       results_dir=results_dir)
 
@@ -57,7 +57,7 @@ for run_data in ["neutron", "nist"]:
         group_names = ['NIST, "lower" difficulty', 'NIST, "average" difficulty',
                        'NIST, "higher" difficulty']
         group_suffix_names = ['nist_lower', 'nist_average', 'nist_higher']
-        problems, results_per_group = fitBenchmarking(nist_group_dir=nist_group_dir,
+        problems, results_per_group, results_dir = fitBenchmarking(nist_group_dir=nist_group_dir,
                                                       minimizers=minimizers, use_errors=use_errors,
                                                       results_dir=results_dir)
 

--- a/fitbenchmarking/fitting_benchmarking.py
+++ b/fitbenchmarking/fitting_benchmarking.py
@@ -234,6 +234,34 @@ def make_plots(prob, group_results_dir, best_fit, wks, previous_name, count, use
     if not os.path.exists(figures_dir):
         os.makedirs(figures_dir)
 
+    # remove the extension (e.g. .nxs) if there is one
+    run_ID = prob.name
+    k = -1
+    k = run_ID.rfind(".")
+    if k != -1:
+        run_ID = run_ID[:k]
+
+    data_fig=plot()
+    tmp=msapi.ConvertToPointData(wks)
+    xData = tmp.readX(0)
+    yData = tmp.readY(0)
+    eData = tmp.readE(0)
+    raw = data("Data",xData,yData,eData)
+    raw.showError = True
+    raw.linestyle = ''
+    data_fig.add_data(raw)
+    data_fig.labels['y'] = "Arbitrary units"
+    data_fig.labels['x'] = "Time ($\mu s$)"
+    if prob.name == previous_name:
+        count+=1
+    else:
+        count =1
+        previous_name = prob.name
+    data_fig.labels['title'] = prob.name[:-4]+" "+str(count)
+    data_fig.title_size=10
+    data_fig.make_scatter_plot(figures_dir + os.sep + "Data Plot " + run_ID + " " +
+                          str(count)+".png")
+
 
     fig=plot()
     best_fit.markers=''
@@ -251,14 +279,11 @@ def make_plots(prob, group_results_dir, best_fit, wks, previous_name, count, use
     fig.add_data(raw)
     fig.labels['y'] = "Arbitrary units"
     fig.labels['x'] = "Time ($\mu s$)"
-    if prob.name == previous_name:
-        count+=1
-    else:
-        count =1
-        previous_name = prob.name
-    #fig.labels['y']="something "
     fig.labels['title'] = prob.name[:-4]+" "+str(count)
     fig.title_size=10
+    fig.make_scatter_plot(figures_dir + os.sep + "Fit for " + run_ID + " " +
+                          str(count) + ".png")
+
 
     fit_result= msapi.Fit(user_func, wks, Output='ws_fitting_test',
                           Minimizer='Levenberg-Marquardt',
@@ -279,21 +304,10 @@ def make_plots(prob, group_results_dir, best_fit, wks, previous_name, count, use
     start_fig.labels['y'] = "Arbitrary units"
     title = user_func[27:-1]
     title = splitByString(title,30)
-
-    # remove the extension (e.g. .nxs) if there is one
-    run_ID = prob.name
-    k = -1
-    k = run_ID.rfind(".")
-    if k != -1:
-        run_ID = run_ID[:k]
-
     start_fig.labels['title'] = run_ID+" "+str(count)+"\n"+title
     start_fig.title_size = 10
-
-    fig.make_scatter_plot(figures_dir + os.sep +
-                          "Fit for "+run_ID+" "+str(count)+".pdf")
-    start_fig.make_scatter_plot(figures_dir + os.sep +
-                                "start for " + run_ID + " " + str(count) + ".pdf")
+    start_fig.make_scatter_plot(figures_dir + os.sep + "start for " + run_ID +
+                                " " + str(count) + ".png")
 
     return previous_name, count
 

--- a/fitbenchmarking/fitting_benchmarking.py
+++ b/fitbenchmarking/fitting_benchmarking.py
@@ -262,11 +262,6 @@ def make_plots(prob, visuals_dir, best_fit, wks, previous_name, count, user_func
     data_fig.add_data(raw)
     data_fig.labels['y'] = "Arbitrary units"
     data_fig.labels['x'] = "Time ($\mu s$)"
-    if prob.name == previous_name:
-        count+=1
-    else:
-        count =1
-        previous_name = prob.name
     data_fig.labels['title'] = prob.name[:-4]+" "+str(count)
     data_fig.title_size=10
     data_fig.make_scatter_plot(figures_dir + os.sep + "Data Plot " + run_ID + " " +

--- a/fitbenchmarking/results_output.py
+++ b/fitbenchmarking/results_output.py
@@ -162,6 +162,7 @@ def build_visual_display_page(prob_results, group_name):
     figures_dir = os.path.join(current_dir, 'results', 'neutron', 'Figures')
     file_name = os.path.join(figures_dir, file_name)
 
+    figure_data = os.path.join(figures_dir, "Data_Plot_" + problem_name + "_1" + ".png")
     figure_fit = os.path.join(figures_dir, "Fit_for_" + problem_name + "_1" + ".png")
     figure_start = os.path.join(figures_dir, "start_for_" + problem_name + "_1" + ".png")
 
@@ -171,16 +172,14 @@ def build_visual_display_page(prob_results, group_name):
     title += '=' * len(gb.problem.name) + '\n\n'
     data_plot = 'Plot of the data' + '\n'
     data_plot += ('-' * len(data_plot)) + '\n\n'
-    data_plot += '.. image:: ' + figure_fit + '\n\n'
+    data_plot += '.. image:: ' + figure_data + '\n\n'
     starting_plot = 'Plot of the initial starting guess' + '\n'
     starting_plot += ('-' * len(starting_plot)) + '\n\n'
     starting_plot += '.. figure:: ' + figure_start  + '\n\n'
     solution_plot = 'Plot of the solution found' + '\n'
     solution_plot += ('-' * len(solution_plot)) + '\n\n'
     solution_plot += '.. figure:: ' + figure_fit + '\n\n'
-    problem = 'Fit problem' + '\n'
-    problem += ('-' * len(problem)) + '\n'
-    rst_text = title + data_plot + starting_plot + solution_plot + problem
+    rst_text = title + data_plot + starting_plot + solution_plot
 
     html = publish_string(rst_text, writer_name='html')
     with open(file_name + '.' + FILENAME_EXT_TXT, 'w') as visual_rst:

--- a/fitbenchmarking/results_output.py
+++ b/fitbenchmarking/results_output.py
@@ -169,7 +169,7 @@ def build_visual_display_page(prob_results, group_name, results_dir):
     rst_link = "<file:///" + rst_file_path + "." + FILENAME_EXT_HTML + ">`__"
 
     # Get path to the figures
-    figures_dir = os.path.join(support_pages_dir, 'Figures')
+    figures_dir = os.path.join(support_pages_dir, 'figures')
 
     figure_data = os.path.join(figures_dir, "Data_Plot_" + problem_name + "_1" + ".png")
     figure_fit = os.path.join(figures_dir, "Fit_for_" + problem_name + "_1" + ".png")

--- a/fitbenchmarking/results_output.py
+++ b/fitbenchmarking/results_output.py
@@ -165,7 +165,7 @@ def build_visual_display_page(prob_results, group_name, results_dir):
     file_path = os.path.join(VDPages_dir, file_name)
 
     rst_file_path = file_path.replace('\\', '/')
-    rst_link = "<file:///" +'' + rst_file_path + "." + FILENAME_EXT_HTML + ">`__"
+    rst_link = "<file:///" + rst_file_path + "." + FILENAME_EXT_HTML + ">`__"
 
     # Get path to the figures
     figures_dir = os.path.join(VDPages_dir, 'Figures')
@@ -173,7 +173,6 @@ def build_visual_display_page(prob_results, group_name, results_dir):
     figure_data = os.path.join(figures_dir, "Data_Plot_" + problem_name + "_1" + ".png")
     figure_fit = os.path.join(figures_dir, "Fit_for_" + problem_name + "_1" + ".png")
     figure_start = os.path.join(figures_dir, "start_for_" + problem_name + "_1" + ".png")
-
 
     # Create various page headings, ensuring the adornment is (at least) the length of the title
     title = '=' * len(gb.problem.name) + '\n'
@@ -199,8 +198,6 @@ def build_visual_display_page(prob_results, group_name, results_dir):
         print(html, file=visual_html)
         logger.info('Saved {file_name}.{extension} to {working_directory}'.
                      format(file_name=file_name, extension=FILENAME_EXT_HTML, working_directory=VDPages_dir))
-
-    rst_link = '`<' + file_name + '.' + FILENAME_EXT_HTML + '>`_'
 
     return rst_link
 

--- a/fitbenchmarking/results_output.py
+++ b/fitbenchmarking/results_output.py
@@ -186,14 +186,14 @@ def build_visual_display_page(prob_results, group_name, results_dir):
     rst_text = title + data_plot + starting_plot + solution_plot
 
     html = publish_string(rst_text, writer_name='html')
-    with open(file_name + '.' + FILENAME_EXT_TXT, 'w') as visual_rst:
+    with open(file_path + '.' + FILENAME_EXT_TXT, 'w') as visual_rst:
         print(html, file=visual_rst)
         print('Saved {file_name}.{extension} to {working_directory}'.
-              format(file_name=file_name, extension=FILENAME_EXT_TXT, working_directory=WORKING_DIR))
-    with open(file_name + '.' + FILENAME_EXT_HTML, 'w') as visual_html:
+              format(file_name=file_name, extension=FILENAME_EXT_TXT, working_directory=VDPages_dir))
+    with open(file_path + '.' + FILENAME_EXT_HTML, 'w') as visual_html:
         print(html, file=visual_html)
         print('Saved {file_name}.{extension} to {working_directory}'.
-              format(file_name=file_name, extension=FILENAME_EXT_HTML, working_directory=WORKING_DIR))
+              format(file_name=file_name, extension=FILENAME_EXT_HTML, working_directory=VDPages_dir))
 
     return rst_link
 

--- a/fitbenchmarking/results_output.py
+++ b/fitbenchmarking/results_output.py
@@ -25,6 +25,7 @@ formats such as RST and plain text.
 from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
+import glob
 from docutils.core import publish_string
 import post_processing as postproc
 import os
@@ -148,27 +149,35 @@ def build_visual_display_page(prob_results, group_name):
     @param prob_results:: the list of results for a problem
     @param group_name :: the name of the group, e.g. "nist_lower"
     """
-    
+
     # Get the best result for a group
     gb = min((result for result in prob_results), key=lambda result: result.fit_chi_sq)
     no_commas_problem_name = gb.problem.name.replace(',', '')
     problem_name = no_commas_problem_name.replace(' ','_')
 
     file_name = (group_name + '_' + problem_name).lower()
-    
+
+    # Get path to the figures
+    current_dir = os.path.dirname(os.path.realpath(__file__))
+    figures_dir = os.path.join(current_dir, 'results', 'neutron', 'Figures')
+    file_name = os.path.join(figures_dir, file_name)
+
+    figure_fit = os.path.join(figures_dir, "Fit_for_" + problem_name + "_1" + ".png")
+    figure_start = os.path.join(figures_dir, "start_for_" + problem_name + "_1" + ".png")
+
     # Create various page headings, ensuring the adornment is (at least) the length of the title
     title = '=' * len(gb.problem.name) + '\n'
     title += gb.problem.name + '\n'
     title += '=' * len(gb.problem.name) + '\n\n'
     data_plot = 'Plot of the data' + '\n'
     data_plot += ('-' * len(data_plot)) + '\n\n'
-    data_plot += '.. image:: ' + file_name + '.png' + '\n\n'
+    data_plot += '.. image:: ' + figure_fit + '\n\n'
     starting_plot = 'Plot of the initial starting guess' + '\n'
     starting_plot += ('-' * len(starting_plot)) + '\n\n'
-    starting_plot += '.. figure:: ' + '\n\n'
+    starting_plot += '.. figure:: ' + figure_start  + '\n\n'
     solution_plot = 'Plot of the solution found' + '\n'
     solution_plot += ('-' * len(solution_plot)) + '\n\n'
-    solution_plot += '.. figure:: ' + '\n\n'
+    solution_plot += '.. figure:: ' + figure_fit + '\n\n'
     problem = 'Fit problem' + '\n'
     problem += ('-' * len(problem)) + '\n'
     rst_text = title + data_plot + starting_plot + solution_plot + problem


### PR DESCRIPTION
#### Description of Work

Fixes #64
Visual display pages now work and display some basic figures.

#### Testing Instructions

1. Run `example_runScripts.py` in mantidpython.
2. Go to the neutron tables, open them and then click on the links.
    - neutron tables are located at "/fitbenchmarking/fitbenchmarking/results/neutron/Tables"
